### PR TITLE
[#1] Replace mae_macros path dep with git dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ test-requires-docker = []
 panic = "unwind"
 
 [dependencies]
-mae_macros = {path = "../macros"}
+mae_macros = { git = "ssh://git@github.com/Mae-Technologies/mae_macros.git" }
 chrono = { version = "0.4.43", features = ["serde"] }
 serde_json = "1.0.149"
 sqlx = { version = "0.8.6", default-features = false, features = ["chrono", "macros", "postgres", "runtime-async-std"] }


### PR DESCRIPTION
Closes #1

## Summary

Replaces the local path dependency on `mae_macros` with a git dependency pointing to `Mae-Technologies/mae_macros`. This fixes cargo resolution when `mae` is consumed as a git dependency from any downstream crate.

## What Changed

- `Cargo.toml`: `mae_macros = { path = "../macros" }` → `mae_macros = { git = "https://github.com/Mae-Technologies/mae_macros" }`

## Test Plan

1. In a scratch crate, add `mae` as a git dep: `mae = { git = "https://github.com/Mae-Technologies/mae" }`
2. Run `cargo fetch` — should resolve without errors
3. Run `cargo build` — should compile successfully
