### PR TITLE
fix: switch mae_macros dep to HTTPS URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2229,7 +2229,7 @@ dependencies = [
 [[package]]
 name = "mae_macros"
 version = "0.1.0"
-source = "git+ssh://git@github.com/Mae-Technologies/mae_macros.git#866b4953aad5f69dd3b3f24ce788528c38699f12"
+source = "git+https://github.com/Mae-Technologies/mae_macros.git#866b4953aad5f69dd3b3f24ce788528c38699f12"
 dependencies = [
  "chrono",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ test-requires-docker = []
 panic = "unwind"
 
 [dependencies]
-mae_macros = { git = "ssh://git@github.com/Mae-Technologies/mae_macros.git" }
+mae_macros = { git = "https://github.com/Mae-Technologies/mae_macros.git" }
 chrono = { version = "0.4.43", features = ["serde"] }
 serde_json = "1.0.149"
 sqlx = { version = "0.8.6", default-features = false, features = ["chrono", "macros", "postgres", "runtime-async-std"] }

--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,7 @@ allow = [
 ]
 
 [advisories]
+db-urls = ["https://github.com/RustSec/advisory-db"]
 unmaintained = "workspace"
 
 [bans]


### PR DESCRIPTION
## Problem

Concourse workers have no GitHub SSH key. `mae`'s `Cargo.toml` references `mae_macros` via `ssh://git@github.com/...` — when services depend on `mae`, Cargo also fetches `mae_macros` via SSH and fails.

## Fix

Change `mae_macros` dep to `https://github.com/Mae-Technologies/mae_macros.git`. No SSH key required.

Also adds `db-urls` to `deny.toml` to pin the advisory-db fetch to HTTPS, and removes a conflicting `url.insteadOf` rule that was redirecting HTTPS → SSH.

**Unblocks all Concourse service builds.**