### PR TITLE
[#38] feat: create src/testing/ module with Must/MustExpect/DotEnv under test-utils feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "./README.md"
 repository = "https://github.com/MrCartaaa/mae"
 
 [features]
+test-utils = ["dep:pretty_assertions", "dep:url", "dep:dotenvy", "dep:shellexpand"]
 test-requires-docker = []
 
 [profile.test]
@@ -36,6 +37,12 @@ tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.22", default-features = false, features = ["env-filter", "registry"] }
 thiserror = "2.0.17"
 rand = { version = "0.9.2", features = ["std_rng"] }
+
+# Optional: only needed when test-utils feature is enabled
+pretty_assertions = { version = "1.4.1", optional = true }
+url = { version = "2.5.8", optional = true }
+dotenvy = { version = "0.15.7", optional = true }
+shellexpand = { version = "3.1.1", optional = true }
 
 [dev-dependencies]
 once_cell = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,4 +12,5 @@ pub mod request_context;
 pub mod routes;
 pub mod session;
 pub mod telemetry;
+pub mod testing;
 pub mod util;

--- a/src/testing/env.rs
+++ b/src/testing/env.rs
@@ -1,0 +1,232 @@
+use std::env;
+use std::fmt::Write;
+use std::sync::OnceLock;
+
+use url::Url;
+
+use super::must::MustExpect;
+
+static CONFIG: OnceLock<DotEnv,> = OnceLock::new();
+
+#[derive(Debug,)]
+pub struct DotEnv {
+    // TODO: This is rediculous, we should just build a config from yaml and add it to our ctx
+    // --------------------------------------------------------------------- */
+    // Migration paths                                                       */
+    // ---------------------------------------------------------------------
+    pub admin_migrations_path: String,
+    pub app_migrations_path: String,
+
+    // --------------------------------------------------------------------- */
+    // Database identity / networking                                        */
+    // ---------------------------------------------------------------------
+    pub db_host: String,
+    pub _db_port: u16,
+    pub app_db_name: String,
+
+    // --------------------------------------------------------------------- */
+    // Roles / credentials                                                   */
+    // ---------------------------------------------------------------------
+    pub superuser: String,
+    pub superuser_pwd: String,
+
+    pub migrator_user: String,
+    pub migrator_pwd: String,
+
+    pub app_user: String,
+    pub app_user_pwd: String,
+
+    pub table_provisioner_user: String,
+    pub table_provisioner_pwd: String,
+
+    // --------------------------------------------------------------------- */
+    // Connection strings                                                    */
+    // ---------------------------------------------------------------------
+    pub search_path: String,
+
+    pub _super_database_url: String,
+    pub _migrator_database_url: String,
+    pub _app_database_url: String,
+    pub _table_creator_database_url: String,
+
+    /// sqlx default
+    pub _database_url: String,
+}
+
+impl DotEnv {
+    /// Build a Postgres DATABASE_URL using primitive env vars,
+    /// overriding the port with `port`.
+    ///
+    /// Example:
+    /// postgres://user:pwd@host:port/db?options=-csearch_path%3Dapp
+    pub fn database_url_with_port(&self, port: u16,) -> String {
+        build_pg_url(
+            &self.migrator_user,
+            &self.migrator_pwd,
+            &self.db_host,
+            port,
+            &self.app_db_name,
+            Some(&self.search_path,),
+        )
+    }
+
+    /// Same builder for the app runtime user.
+    pub fn app_database_url_with_port(&self, port: u16,) -> String {
+        build_pg_url(
+            &self.app_user,
+            &self.app_user_pwd,
+            &self.db_host,
+            port,
+            &self.app_db_name,
+            Some(&self.search_path,),
+        )
+    }
+
+    /// Same builder for the superuser.
+    pub fn super_database_url_with_port(&self, port: u16,) -> String {
+        build_pg_url(
+            &self.superuser,
+            &self.superuser_pwd,
+            &self.db_host,
+            port,
+            &self.app_db_name,
+            None,
+        )
+    }
+
+    /// Same builder for the table provisioner.
+    pub fn table_creator_database_url_with_port(&self, port: u16,) -> String {
+        build_pg_url(
+            &self.table_provisioner_user,
+            &self.table_provisioner_pwd,
+            &self.db_host,
+            port,
+            &self.app_db_name,
+            Some(&self.search_path,),
+        )
+    }
+}
+
+fn build_pg_url(
+    user: &str,
+    password: &str,
+    host: &str,
+    port: u16,
+    db_name: &str,
+    search_path: Option<&str,>,
+) -> String {
+    let mut url = String::with_capacity(128,);
+
+    // scheme + creds
+    let _ = write!(&mut url, "postgres://{}:{}@{}:{}/{}", user, password, host, port, db_name);
+
+    // optional query (already percent-encoded in env)
+    let _ = match search_path {
+        Some(v,) => write!(&mut url, "?{}", v),
+        None => Ok((),),
+    };
+    url
+}
+
+pub fn load() -> &'static DotEnv {
+    CONFIG.get_or_init(|| {
+        // Load .env once (noop if missing)
+        dotenvy::dotenv().ok();
+
+        // ---------------- migration paths ----------------
+        let admin_migrations_path = get("ADMIN_MIGRATIONS_PATH",);
+        let app_migrations_path = get("APP_MIGRATIONS_PATH",);
+
+        // ---------------- db identity ----------------
+        let db_host = get("DB_HOST",);
+        let db_port: u16 = get("DB_PORT",).parse().must_expect("DB_PORT must be a valid u16",);
+        let app_db_name = get("APP_DB_NAME",);
+
+        // ---------------- roles ----------------
+        let superuser = get("SUPERUSER",);
+        let superuser_pwd = get("SUPERUSER_PWD",);
+
+        let migrator_user = get("MIGRATOR_USER",);
+        let migrator_pwd = get("MIGRATOR_PWD",);
+
+        let app_user = get("APP_USER",);
+        let app_user_pwd = get("APP_USER_PWD",);
+
+        let table_provisioner_user = get("TABLE_PROVISIONER_USER",);
+        let table_provisioner_pwd = get("TABLE_PROVISIONER_PWD",);
+
+        // ---------------- urls ----------------
+        let search_path = get("SEARCH_PATH",);
+
+        let raw = get("SUPER_DATABASE_URL",);
+        let super_database_url = shellexpand::env(&raw,)
+            .must_expect("DATABASE_URL contains unknown env vars",)
+            .into_owned();
+
+        let raw = get("MIGRATOR_DATABASE_URL",);
+        let migrator_database_url = shellexpand::env(&raw,)
+            .must_expect("DATABASE_URL contains unknown env vars",)
+            .into_owned();
+
+        let raw = get("DATABASE_URL",);
+        let database_url = shellexpand::env(&raw,)
+            .must_expect("DATABASE_URL contains unknown env vars",)
+            .into_owned();
+
+        let raw = get("APP_DATABASE_URL",);
+        let app_database_url = shellexpand::env(&raw,)
+            .must_expect("DATABASE_URL contains unknown env vars",)
+            .into_owned();
+
+        let raw = get("TABLE_CREATOR_DATABASE_URL",);
+        let table_creator_database_url = shellexpand::env(&raw,)
+            .must_expect("DATABASE_URL contains unknown env vars",)
+            .into_owned();
+
+        // ---------------- safety guards ----------------
+        assert_test_database(&super_database_url,);
+        assert_test_database(&database_url,);
+        assert_test_database(&migrator_database_url,);
+        assert_test_database(&app_database_url,);
+        assert_test_database(&table_creator_database_url,);
+
+        DotEnv {
+            admin_migrations_path,
+            app_migrations_path,
+            db_host,
+            _db_port: db_port,
+            app_db_name,
+            superuser,
+            superuser_pwd,
+            migrator_user,
+            migrator_pwd,
+            app_user,
+            app_user_pwd,
+            table_provisioner_user,
+            table_provisioner_pwd,
+            search_path,
+            _super_database_url: super_database_url,
+            _migrator_database_url: migrator_database_url,
+            _app_database_url: app_database_url,
+            _table_creator_database_url: table_creator_database_url,
+            _database_url: database_url,
+        }
+    },)
+}
+
+fn get(key: &str,) -> String {
+    env::var(key,).must_expect(&format!("{key} must be set (env or .env)"),)
+}
+
+fn assert_test_database(database_url: &str,) {
+    let url = Url::parse(database_url,)
+        .must_expect(&format!("DATABASE_URL must be a valid URL: {}", database_url),);
+
+    let db_name = url
+        .path_segments()
+        .and_then(|mut s| s.next_back(),)
+        .filter(|s| !s.is_empty(),)
+        .must_expect("DATABASE_URL must include a database name",);
+
+    assert!(db_name.contains("_test"), "Refusing to run against non-test database: '{db_name}'");
+}

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -1,0 +1,4 @@
+#[cfg(feature = "test-utils")]
+pub mod env;
+#[cfg(feature = "test-utils")]
+pub mod must;

--- a/src/testing/must.rs
+++ b/src/testing/must.rs
@@ -1,0 +1,171 @@
+use pretty_assertions::{assert_eq, assert_ne};
+use std::panic::Location;
+
+/// Trait for safe test assertions on `Option` and `Result`.
+pub trait Must<T,> {
+    /// Panics if the value is not as expected, with caller location.
+    #[track_caller]
+    fn must(self,) -> T;
+}
+
+pub trait MustExpect<T,>: Sized {
+    /// Like `expect`, but includes caller location in the panic message.
+    #[track_caller]
+    fn must_expect(self, msg: &str,) -> T;
+}
+
+impl<T,> Must<T,> for Option<T,> {
+    #[track_caller]
+    fn must(self,) -> T {
+        self.unwrap_or_else(|| {
+            panic!("test invariant failed: expected Some, got None at {}", Location::caller())
+        },)
+    }
+}
+
+impl<T,> MustExpect<T,> for Option<T,> {
+    #[track_caller]
+    fn must_expect(self, msg: &str,) -> T {
+        self.unwrap_or_else(|| {
+            panic!("{} (expected Some, got None) at {}", msg, Location::caller())
+        },)
+    }
+}
+
+impl<T, E: std::fmt::Debug,> Must<T,> for Result<T, E,> {
+    #[track_caller]
+    fn must(self,) -> T {
+        self.unwrap_or_else(|err| {
+            panic!("test invariant failed: expected Ok, got {:?} at {}", err, Location::caller())
+        },)
+    }
+}
+
+impl<T, E: std::fmt::Debug,> MustExpect<T,> for Result<T, E,> {
+    #[track_caller]
+    fn must_expect(self, msg: &str,) -> T {
+        self.unwrap_or_else(|err| {
+            panic!("{} (expected Ok, got {:?}) at {}", msg, err, Location::caller())
+        },)
+    }
+}
+
+// ── Convenience free functions ──────────────────────────────────────────────
+
+#[track_caller]
+pub fn must_be_some<T,>(opt: Option<T,>,) -> T {
+    opt.must()
+}
+
+#[track_caller]
+pub fn must_be_ok<T, E: std::fmt::Debug,>(res: Result<T, E,>,) -> T {
+    res.must()
+}
+
+#[track_caller]
+pub fn must_expect_some<T,>(opt: Option<T,>, msg: &str,) -> T {
+    opt.must_expect(msg,)
+}
+
+#[track_caller]
+pub fn must_expect_ok<T, E: std::fmt::Debug,>(res: Result<T, E,>, msg: &str,) -> T {
+    res.must_expect(msg,)
+}
+
+#[allow(clippy::disallowed_methods)]
+#[track_caller]
+pub fn must_eq<V: PartialEq + std::fmt::Debug,>(left: V, right: V,) {
+    assert_eq!(left, right);
+}
+
+#[track_caller]
+pub fn must_ne<V: PartialEq + std::fmt::Debug,>(left: V, right: V,) {
+    assert_ne!(left, right);
+}
+
+#[track_caller]
+pub fn must_be_true(b: bool,) {
+    assert!(b);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn option_must_some_ok() {
+        let v = Some(42,).must();
+        must_eq(v, 42,);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected Some, got None")]
+    fn option_must_none_panics() {
+        let _: i32 = None.must();
+    }
+
+    #[test]
+    fn option_must_expect_ok() {
+        let v = Some("hello",).must_expect("should have value",);
+        must_eq(v, "hello",);
+    }
+
+    #[test]
+    #[should_panic(expected = "custom msg")]
+    fn option_must_expect_panics_with_msg() {
+        let _: i32 = None.must_expect("custom msg",);
+    }
+
+    #[test]
+    fn result_must_ok() {
+        let v: i32 = Ok::<i32, &str,>(7,).must();
+        must_eq(v, 7,);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected Ok")]
+    fn result_must_err_panics() {
+        let r: Result<i32, &str,> = Err("boom",);
+        let _ = r.must();
+    }
+
+    #[test]
+    fn result_must_expect_ok() {
+        let v: &str = Ok::<&str, &str,>("yes",).must_expect("should succeed",);
+        must_eq(v, "yes",);
+    }
+
+    #[test]
+    #[should_panic(expected = "should fail")]
+    fn result_must_expect_panics_with_msg() {
+        let r: Result<i32, &str,> = Err("nope",);
+        let _ = r.must_expect("should fail",);
+    }
+
+    #[test]
+    fn free_helpers_work() {
+        let a = must_be_some(Some(1,),);
+        let b = must_be_ok::<_, &str,>(Ok::<i32, &str,>(2,),);
+        let c = must_expect_some(Some(3,), "msg",);
+        let d = must_expect_ok::<_, &str,>(Ok::<i32, &str,>(4,), "msg",);
+
+        must_eq(a + b + c + d, 10,);
+    }
+
+    #[test]
+    fn must_eq_and_ne() {
+        must_eq(5, 5,);
+        must_ne(5, 6,);
+    }
+
+    #[test]
+    fn must_be_true_works() {
+        must_be_true(true,);
+    }
+
+    #[test]
+    #[should_panic]
+    fn must_be_true_panics_on_false() {
+        must_be_true(false,);
+    }
+}


### PR DESCRIPTION
Closes #38
Refs #37

## Summary
Creates a `src/testing/` library module that re-exports `Must`, `MustExpect`, and `DotEnv` utilities under the `test-utils` feature flag, making them available to downstream crates consuming `mae`.

## Changes
- **`Cargo.toml`**: Added `test-utils` feature; moved `pretty_assertions`, `url`, `dotenvy`, `shellexpand` to optional dependencies enabled by that feature (kept in dev-deps too for existing test infra).
- **`src/testing/mod.rs`**: New module root gating `must` and `env` submodules behind `#[cfg(feature = "test-utils")]`.
- **`src/testing/must.rs`**: Copied from `tests/common/must.rs`; removed `#[cfg(test)]` guards so traits/impls are public under the feature flag.
- **`src/testing/env.rs`**: Copied from `tests/common/env.rs`; fully public under the feature flag.
- **`src/lib.rs`**: Added `pub mod testing;`.

## Verification
- `cargo +nightly check --features test-utils` ✅
- `cargo +nightly check` ✅
- `cargo +nightly test --lib` ✅
- `cargo +nightly fmt -- --check` ✅
- `cargo +nightly clippy --all-targets --all-features -- -D warnings` ✅