### PR TITLE
chore: cargo update mae_macros to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2266,7 +2266,7 @@ dependencies = [
 [[package]]
 name = "mae_macros"
 version = "0.1.0"
-source = "git+https://github.com/Mae-Technologies/mae_macros.git#866b4953aad5f69dd3b3f24ce788528c38699f12"
+source = "git+https://github.com/Mae-Technologies/mae_macros.git#9e1735a777e255f599bca7a8b3a3e941a9c97b78"
 dependencies = [
  "chrono",
  "proc-macro2",

--- a/tests/common/context.rs
+++ b/tests/common/context.rs
@@ -243,7 +243,7 @@ mod test_context {
     use mae_macros::mae_test;
 
     #[cfg_attr(miri, ignore)]
-    #[mae_test(not_async)]
+    #[mae_test]
     async fn parallelism() -> Result<(),> {
         // Create an isolated schema for this test run.
         let ctx = get_context().await?;
@@ -263,7 +263,7 @@ mod test_context {
     }
 
     #[cfg_attr(miri, ignore)]
-    #[mae_test(not_async)]
+    #[mae_test]
     async fn uses_test_context_schema_isolation() -> Result<(),> {
         // Create an isolated schema for this test run.
         let ctx = get_context().await?;

--- a/tests/repo/crud.rs
+++ b/tests/repo/crud.rs
@@ -16,7 +16,7 @@ pub use sqlx::types::JsonValue as SqlxJson;
 /// expected field types. This is a compile-time smoke test — if the struct fields or
 /// their types change, this test fails to compile before any DB is involved.
 #[cfg_attr(miri, ignore)]
-#[mae_test(not_async)]
+#[mae_test]
 fn should_make_domain_struct() {
     let _my_repo = fixture::RepoExample {
         value: 1,


### PR DESCRIPTION
Updates mae's own Cargo.lock to pick up mae_macros@9e1735a7 (#[mae_test] macro fix, clippy compliance, optional teardown, docker gate).

Also removes `not_async` from `#[mae_test]` usages in tests — argument no longer supported; valid args: `docker`, `teardown = <path>`.

Refs Mae-Technologies/mae#37
Refs Mae-Technologies/mae_macros#5