### PR TITLE
[#21] feat: implement ctx parameter in Interface trait methods

### DIFF
--- a/src/repo/build.rs
+++ b/src/repo/build.rs
@@ -28,7 +28,7 @@ use num::Zero;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-use sqlx::{Arguments, Executor, Postgres};
+use sqlx::Arguments;
 
 use crate::repo::filter::Filter;
 use crate::request_context::ContextAccessor;
@@ -362,45 +362,45 @@ pub trait ToSql<I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,> {
 /// Async execution layer for a built query.
 ///
 /// Implemented automatically for any [`Builder`] that also implements [`ToSql`].
-/// The `fetch_all` method is the primary entry point for most callers; `execute` is
-/// for fire-and-forget mutations that don't need returned rows.
+/// The context (`ctx`) is stored in the builder at construction time via [`Interface`]
+/// methods, so all `Execute` methods resolve the DB pool internally — callers do
+/// **not** need to pass the pool or context at the execution step.
+///
+/// ```rust,ignore
+/// // New — ctx carried through from the Interface call:
+/// Account::select(ctx, vec![Field::All]).fetch_all().await?;
+///
+/// // Old — caller had to pass the executor explicitly:
+/// Account::select(vec![Field::All]).fetch_all(ctx.db_pool()).await?;
+/// ```
 pub trait Execute<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,>:
     ToSql<I, U, F, P,> + ContextAccessor
 {
     /// Execute the statement without returning rows (e.g. a side-effect-only mutation).
-    fn execute(&self, _ctx: &C,) -> impl std::future::Future<Output = anyhow::Result<(),>,> + Send
+    ///
+    /// Uses the DB pool stored in the builder's context.
+    fn execute(&self,) -> impl std::future::Future<Output = anyhow::Result<(),>,> + Send
     where
-        Self: Sync,
+        Self: Sync + Send,
     {
-        async { todo!() }
+        async move {
+            self.authenticate_request()?;
+            let sql = self.to_sql()?;
+            let req =
+                sqlx::query_with::<sqlx::Postgres, _,>(&sql, self.args(self.session_user(),),);
+            req.execute(self.db_pool(),)
+                .await
+                .map(|_| (),)
+                .map_err(|e| anyhow::anyhow!("Unable to execute: {}", e),)
+        }
     }
+
+    /// Execute and return at most one row, or `None` if no row matched.
+    ///
+    /// Uses the DB pool stored in the builder's context.
     fn fetch_optional(
         &self,
-        _ctx: &C,
     ) -> impl std::future::Future<Output = anyhow::Result<Option<A,>,>,> + Send
-    where
-        Self: Sync,
-    {
-        async { todo!() }
-    }
-    /// Execute and return exactly one row, erroring if zero or more than one row is returned.
-    fn fetch_one(&self, _ctx: &C,) -> impl std::future::Future<Output = anyhow::Result<A,>,> + Send
-    where
-        Self: Sync,
-    {
-        async { todo!() }
-    }
-    /// Execute and return all matching rows.
-    ///
-    /// Runs [`authenticate_request`](Self::authenticate_request) first — this guards against
-    /// Update/Patch without filters and SELECT with the wrong field count.
-    ///
-    /// Pass a `&mut Transaction` to participate in the caller's transaction, or the pool
-    /// directly for auto-commit behaviour.
-    fn fetch_all<'c,>(
-        &self,
-        exec: impl Executor<'c, Database = Postgres,>,
-    ) -> impl std::future::Future<Output = anyhow::Result<Vec<A,>,>,> + Send
     where
         Self: Sync + Send,
     {
@@ -411,11 +411,53 @@ pub trait Execute<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToF
                 &sql,
                 self.args(self.session_user(),),
             );
-            let res: anyhow::Result<Vec<A,>,> = req
-                .fetch_all(exec,)
+            req.fetch_optional(self.db_pool(),)
                 .await
-                .map_err(|e| anyhow::anyhow!("Unable to fetch all: {}", e),);
-            res
+                .map_err(|e| anyhow::anyhow!("Unable to fetch optional: {}", e),)
+        }
+    }
+
+    /// Execute and return exactly one row, erroring if zero or more than one row is returned.
+    ///
+    /// Uses the DB pool stored in the builder's context.
+    fn fetch_one(&self,) -> impl std::future::Future<Output = anyhow::Result<A,>,> + Send
+    where
+        Self: Sync + Send,
+    {
+        async move {
+            self.authenticate_request()?;
+            let sql = self.to_sql()?;
+            let req = sqlx::query_as_with::<'_, sqlx::Postgres, A, sqlx::postgres::PgArguments,>(
+                &sql,
+                self.args(self.session_user(),),
+            );
+            req.fetch_one(self.db_pool(),)
+                .await
+                .map_err(|e| anyhow::anyhow!("Unable to fetch one: {}", e),)
+        }
+    }
+
+    /// Execute and return all matching rows.
+    ///
+    /// Runs [`authenticate_request`](Self::authenticate_request) first — this guards against
+    /// Update/Patch without filters and SELECT with the wrong field count.
+    ///
+    /// Uses the DB pool stored in the builder's context (set when calling [`Interface`]
+    /// methods such as [`Interface::select`]).
+    fn fetch_all(&self,) -> impl std::future::Future<Output = anyhow::Result<Vec<A,>,>,> + Send
+    where
+        Self: Sync + Send,
+    {
+        async move {
+            self.authenticate_request()?;
+            let sql = self.to_sql()?;
+            let req = sqlx::query_as_with::<'_, sqlx::Postgres, A, sqlx::postgres::PgArguments,>(
+                &sql,
+                self.args(self.session_user(),),
+            );
+            req.fetch_all(self.db_pool(),)
+                .await
+                .map_err(|e| anyhow::anyhow!("Unable to fetch all: {}", e),)
         }
     }
     /// Validate the request before hitting the DB.

--- a/tests/repo/crud.rs
+++ b/tests/repo/crud.rs
@@ -7,7 +7,6 @@ use chrono::Utc;
 use mae::repo::default::DomainStatus;
 use mae::repo::filter::{Filter, FilterOp};
 use mae::repo::implement::{Execute, Interface};
-use mae::request_context::ContextAccessor;
 use mae_macros::mae_test;
 pub use serde_json::Map;
 pub use sqlx::types::JsonValue as SqlxJson;
@@ -35,20 +34,17 @@ fn should_make_domain_struct() {
 }
 
 /// Validates that `insert_one` generates correct SQL and successfully inserts a row,
-/// returning the inserted record via `RETURNING *`. Runs inside a transaction that is
-/// rolled back after the test so no data persists in the test DB.
+/// returning the inserted record via `RETURNING *`.
 #[cfg_attr(miri, ignore)]
 #[mae_test]
 async fn should_insert() -> Result<(),> {
     let ctx = get_context().await?;
 
-    let mut tx = ctx.db_pool.begin().await?;
-
     let data = fixture::gen_insert_row(); // let data = RepoExample {
     // };
     let builder = fixture::RepoExample::insert_one(&ctx, data,);
 
-    let res = builder.fetch_all(&mut *tx,).await?;
+    let res = builder.fetch_all().await?;
 
     must_eq(res[0].string_value.as_str(), "hello_world",);
 
@@ -63,8 +59,6 @@ async fn should_insert() -> Result<(),> {
 async fn should_get_empty_records() -> Result<(),> {
     let ctx = get_context().await?;
 
-    let mut tx = ctx.db_pool.begin().await?;
-
     let mut builder = fixture::RepoExample::select(&ctx, vec![Field::All],);
 
     builder = builder.filter(vec![
@@ -72,7 +66,7 @@ async fn should_get_empty_records() -> Result<(),> {
         FilterOp::Or(Field::string_value, Filter::Ilike("hello".to_string(),),),
     ],);
 
-    let res = builder.fetch_all(&mut *tx,).await?;
+    let res = builder.fetch_all().await?;
 
     must_be_true(res.is_empty(),);
     Ok((),)
@@ -86,13 +80,11 @@ async fn should_get_empty_records() -> Result<(),> {
 async fn should_get_records() -> Result<(),> {
     let ctx = get_context().await?;
 
-    let mut tx = ctx.db_pool.begin().await?;
-
     let data = fixture::gen_insert_row();
 
     let builder = fixture::RepoExample::insert_one(&ctx, data.clone(),);
 
-    let res = builder.fetch_all(&mut *tx,).await?;
+    let res = builder.fetch_all().await?;
 
     must_eq(res[0].string_value.as_str(), "hello_world",);
 
@@ -101,7 +93,7 @@ async fn should_get_records() -> Result<(),> {
         FilterOp::And(Field::value, Filter::Equals(1,),),
     ],);
 
-    let res = builder.fetch_all(&mut *tx,).await?;
+    let res = builder.fetch_all().await?;
 
     must_be_true(!res.is_empty(),);
     Ok((),)
@@ -114,12 +106,10 @@ async fn should_get_records() -> Result<(),> {
 async fn should_error_on_update_without_filters() -> Result<(),> {
     let ctx = get_context().await?;
 
-    let mut tx = ctx.db_pool.begin().await?;
-
     let data = fixture::gen_update_row();
     let builder = fixture::RepoExample::update_many(&ctx, data,);
 
-    let res = builder.fetch_all(&mut *tx,).await;
+    let res = builder.fetch_all().await;
     res.err().must();
     // TODO: this should error, but the error message should also be checked.
     Ok((),)
@@ -131,8 +121,6 @@ async fn should_error_on_update_without_filters() -> Result<(),> {
 #[mae_test]
 async fn should_error_on_update_with_row_fields_all_none() -> Result<(),> {
     let ctx = get_context().await?;
-
-    let mut tx = ctx.db_pool.begin().await?;
 
     let data = fixture::UpdateRow {
         status: None,
@@ -146,7 +134,7 @@ async fn should_error_on_update_with_row_fields_all_none() -> Result<(),> {
     builder = builder
         .filter(vec![FilterOp::Begin(Field::string_value, Filter::Like("hello_world".into(),),)],);
 
-    let res = builder.fetch_all(&mut *tx,).await;
+    let res = builder.fetch_all().await;
     // TODO: this should error, but the error message should also be checked.
     res.err().must();
     Ok((),)
@@ -161,18 +149,16 @@ async fn should_error_on_update_with_row_fields_all_none() -> Result<(),> {
 async fn should_update() -> Result<(),> {
     let ctx = get_context().await?;
 
-    let mut tx = ctx.db_pool.begin().await?;
-
     let new_data = fixture::gen_insert_row();
 
-    let _ = RepoExample::insert_one(&ctx, new_data,).fetch_all(ctx.db_pool(),).await;
+    let _ = RepoExample::insert_one(&ctx, new_data,).fetch_all().await;
 
     let data = fixture::gen_update_row();
     let mut builder = fixture::RepoExample::update_many(&ctx, data,);
     builder = builder
         .filter(vec![FilterOp::Begin(Field::string_value, Filter::Like("hello_world".into(),),)],);
 
-    let _res = builder.fetch_all(&mut *tx,).await?;
+    let _res = builder.fetch_all().await?;
 
     // TODO: the result should match the input
     Ok((),)
@@ -185,12 +171,10 @@ async fn should_update() -> Result<(),> {
 async fn should_error_on_patch_without_filters() -> Result<(),> {
     let ctx = get_context().await?;
 
-    let mut tx = ctx.db_pool.begin().await?;
-
     let data = fixture::gen_patches();
     let builder = fixture::RepoExample::patch(&ctx, data,);
 
-    let res = builder.fetch_all(&mut *tx,).await;
+    let res = builder.fetch_all().await;
     //
     must_be_true(res.err().must().to_string().contains("Unable to Update/Patch",),);
     Ok((),)
@@ -204,13 +188,11 @@ async fn should_error_on_patch_without_filters() -> Result<(),> {
 async fn should_error_on_patch_with_fields_empty() -> Result<(),> {
     let ctx = get_context().await.must();
 
-    let mut tx = ctx.db_pool.begin().await?;
-
     let data: Vec<fixture::PatchField,> = vec![];
     let mut builder = fixture::RepoExample::patch(&ctx, data,);
     builder = builder.filter(fixture::gen_filters(),);
 
-    let res = builder.fetch_all(&mut *tx,).await;
+    let res = builder.fetch_all().await;
     //
     must_be_true(res.is_err(),);
     must_be_true(res.err().must().to_string().contains("Unable to Update/Patch",),);
@@ -224,13 +206,11 @@ async fn should_error_on_patch_with_fields_empty() -> Result<(),> {
 async fn patch_should_return_empty() -> Result<(),> {
     let ctx = get_context().await?;
 
-    let mut tx = ctx.db_pool.begin().await?;
-
     let data = fixture::gen_patches();
     let mut builder = fixture::RepoExample::patch(&ctx, data,);
     builder = builder.filter(fixture::gen_filters(),);
 
-    let res = builder.fetch_all(&mut *tx,).await?;
+    let res = builder.fetch_all().await?;
 
     must_be_true(res.is_empty(),);
     Ok((),)
@@ -247,13 +227,11 @@ async fn patch_should_return_empty() -> Result<(),> {
 async fn should_patch() -> Result<(),> {
     let ctx = get_context().await?;
 
-    let mut tx = ctx.db_pool.begin().await?;
-
     let data = fixture::gen_patches();
     let mut builder = fixture::RepoExample::patch(&ctx, data,);
     builder = builder.filter(fixture::gen_filters(),);
 
-    let _res = builder.fetch_all(&mut *tx,).await?;
+    let _res = builder.fetch_all().await?;
 
     // TODO: the result should match the input
     Ok((),)


### PR DESCRIPTION
## Issue
Closes #21

## Summary
Passes the request context through the `Interface` trait so callers don't need to supply the DB pool/executor separately at the execution step.

**Before:**
```rust
Account::select(vec![Field::All]).fetch_all(ctx.db_pool()).await?
```

**After:**
```rust
Account::select(ctx, vec![Field::All]).fetch_all().await?
```

## Changes

### `src/repo/build.rs`
- **`Execute::fetch_all`** — removed `exec: impl Executor` parameter; now uses `self.db_pool()` from the context stored in the `Builder` at construction time.
- **`Execute::fetch_one`** — implemented (was `todo!()`); removed unused `_ctx: &C` parameter; uses `self.db_pool()`.
- **`Execute::fetch_optional`** — implemented (was `todo!()`); removed unused `_ctx: &C` parameter; uses `self.db_pool()`.
- **`Execute::execute`** — implemented (was `todo!()`); removed unused `_ctx: &C` parameter; uses `self.db_pool()`.
- Removed unused `Executor` and `Postgres` imports.

### `tests/repo/crud.rs`
- Removed per-test transaction setup (`ctx.db_pool.begin()`) and updated all `fetch_all(&mut *tx)` → `fetch_all()` calls.
- Removed now-unused `ContextAccessor` import.

## Breaking Changes
- **`Execute::fetch_all`** signature changed: no longer accepts an executor argument. Callers must migrate from `.fetch_all(ctx.db_pool())` to `.fetch_all()`.
- **`Execute::fetch_one`**, **`fetch_optional`**, **`execute`** signatures changed: `_ctx: &C` parameter removed.

## CI
- `cargo fmt -- --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks` ✅
- `cargo miri test --lib` ✅
- `cargo deny check` ✅