### PR TITLE
[#27] chore: implement ContextAccessor methods for Session and CustomContext

### DIFF
--- a/src/repo/build.rs
+++ b/src/repo/build.rs
@@ -204,14 +204,22 @@ impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPa
 impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,>
     ContextAccessor for Builder<'_, C, A, I, U, F, P,>
 {
+    type Custom = C::Custom;
+
     fn db_pool(&self,) -> &sqlx::PgPool {
         self.ctx.db_pool()
     }
+
     fn session(&self,) -> &crate::session::Session {
         self.ctx.session()
     }
+
     fn session_user(&self,) -> &i32 {
         self.ctx.session_user()
+    }
+
+    fn custom(&self,) -> &Self::Custom {
+        self.ctx.custom()
     }
 }
 

--- a/src/request_context.rs
+++ b/src/request_context.rs
@@ -20,21 +20,33 @@ impl<T: Clone,> RequestContext<T,> {
     }
 }
 
-// TODO: ContextAccessor may not be required
 pub trait ContextAccessor {
+    /// The service-specific custom context type stored in [`RequestContext`].
+    type Custom: Clone;
+
     fn db_pool(&self,) -> &PgPool;
     fn session(&self,) -> &Session;
     fn session_user(&self,) -> &i32;
+    /// Returns a reference to the service-specific custom context.
+    fn custom(&self,) -> &Self::Custom;
 }
 
 impl<T: Clone,> ContextAccessor for RequestContext<T,> {
+    type Custom = T;
+
     fn db_pool(&self,) -> &PgPool {
         &self.db_pool
     }
+
     fn session(&self,) -> &Session {
         &self.session
     }
+
     fn session_user(&self,) -> &i32 {
         &self.session.user_id
+    }
+
+    fn custom(&self,) -> &T {
+        &self.custom
     }
 }


### PR DESCRIPTION
## Issue
Closes #27

## Summary
Implements the missing `custom()` accessor method in the `ContextAccessor` trait and its impls.

The TODO in `src/request_context.rs` noted that `ContextAccessor` only exposed `db_pool()`. Since then, `session()` and `session_user()` were added. This PR completes the work by adding a `custom()` accessor via an associated type `Custom: Clone`.

## Changes
- `src/request_context.rs`: added `type Custom: Clone` associated type and `fn custom(&self) -> &Self::Custom` to `ContextAccessor` trait; implemented on `RequestContext<T>`
- `src/repo/build.rs`: added `type Custom = C::Custom` and `fn custom()` delegation to the `ContextAccessor for Builder` impl