### PR TITLE
[#4-dep] feat: add IntoMaeFilter trait for schema macro From impls

### DIFF
--- a/src/repo/into_filter.rs
+++ b/src/repo/into_filter.rs
@@ -1,0 +1,45 @@
+use super::map_util::Filter;
+
+/// Converts a typed value into a [`Filter`] condition.
+///
+/// Implemented for the primitive types that appear in schema field
+/// definitions (`i32`, `String`, `Option<i32>`, `Option<String>`).
+/// The generated `From<PatchField> for FilterOp<Field>` and
+/// `From<UpdateRow> for Vec<FilterOp<Field>>` impls produced by
+/// `#[derive(MaeRepo)]` rely on this trait to pick the correct
+/// [`Filter`] variant for each field type.
+pub trait IntoMaeFilter {
+    /// Convert `self` into a [`Filter`] using an equality /
+    /// string-equality condition appropriate for the value's type.
+    fn into_mae_filter(self,) -> Filter;
+}
+
+impl IntoMaeFilter for i32 {
+    fn into_mae_filter(self,) -> Filter {
+        Filter::Equals(self,)
+    }
+}
+
+impl IntoMaeFilter for String {
+    fn into_mae_filter(self,) -> Filter {
+        Filter::StringIs(self,)
+    }
+}
+
+impl IntoMaeFilter for Option<i32,> {
+    fn into_mae_filter(self,) -> Filter {
+        match self {
+            Some(v,) => Filter::Equals(v,),
+            None => Filter::IsNull,
+        }
+    }
+}
+
+impl IntoMaeFilter for Option<String,> {
+    fn into_mae_filter(self,) -> Filter {
+        match self {
+            Some(v,) => Filter::StringIs(v,),
+            None => Filter::IsNull,
+        }
+    }
+}

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -1,6 +1,7 @@
 pub mod default;
 
 mod build;
+mod into_filter;
 mod map_util;
 // mod sql_parts;
 mod type_def;
@@ -25,5 +26,6 @@ pub mod __private__ {
     use super::*;
     pub use build::Build;
     // TODO: AsSqlParts should be a type;
+    pub use into_filter::IntoMaeFilter;
     pub use map_util::{AsSqlParts, BindArgs, ToSqlParts};
 }


### PR DESCRIPTION
## Issue
Dependency for Mae-Technologies/mae_macros#4

## Summary
Adds `IntoMaeFilter` trait to `mae::repo::__private__` so that the generated `From<PatchField> for FilterOp<Field>` and `From<Row> for Vec<FilterOp<Field>>` impls produced by `#[derive(MaeRepo)]` can map field values to the correct `Filter` variant.

## Changes
- Added `src/repo/into_filter.rs` with `IntoMaeFilter` trait implemented for `i32`, `String`, `Option<i32>`, `Option<String>`
- Re-exported `IntoMaeFilter` from `mae::repo::__private__`