### PR TITLE
[#25] feat: BindArgs::bind returns Result instead of panicking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2266,8 +2266,7 @@ dependencies = [
 [[package]]
 name = "mae_macros"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9146212ad8d8c3b60733ee843436ca9714d20655ba04f3be358a0ebac8ba8f48"
+source = "git+https://github.com/Mae-Technologies/mae_macros.git?branch=feature%2F25-bindargs-bind-returns-result#7c2d2733d64d713596bc7b0f5a54c3eabbef92f3"
 dependencies = [
  "chrono",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ test-utils = [
 panic = "unwind"
 
 [dependencies]
-mae_macros = "0.1.0"
+mae_macros = { git = "https://github.com/Mae-Technologies/mae_macros.git", branch = "feature/25-bindargs-bind-returns-result" }
 chrono = { version = "0.4.43", features = ["serde"] }
 serde_json = "1.0.149"
 sqlx = { version = "0.8.6", default-features = false, features = ["chrono", "macros", "postgres", "runtime-async-std"] }

--- a/src/repo/build.rs
+++ b/src/repo/build.rs
@@ -334,21 +334,21 @@ pub trait ToSql<I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch> {
             }
         })
     }
-    fn args(&self, session_user: &i32) -> sqlx::postgres::PgArguments {
+    fn args(&self, session_user: &i32) -> Result<sqlx::postgres::PgArguments> {
         let mut args = sqlx::postgres::PgArguments::default();
         match self.statement() {
             SqlStatement::Select(_) => {}
             _ => {
-                self.statement().bind(&mut args);
+                self.statement().bind(&mut args)?;
                 // Always bind session_user last for INSERT (created_by) and UPDATE/PATCH
                 // (updated_by). The placeholder is the final positional param in to_sql().
                 let _ = args.add(session_user);
             }
         };
         for w in self.filters().iter() {
-            w.bind(&mut args);
+            w.bind(&mut args)?;
         }
-        args
+        Ok(args)
     }
 }
 
@@ -402,7 +402,7 @@ pub trait Execute<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToF
             let sql = self.to_sql()?;
             let req = sqlx::query_as_with::<'_, sqlx::Postgres, A, sqlx::postgres::PgArguments>(
                 &sql,
-                self.args(self.session_user())
+                self.args(self.session_user())?
             );
             let res: anyhow::Result<Vec<A>> = req
                 .fetch_all(exec)

--- a/src/repo/map_util.rs
+++ b/src/repo/map_util.rs
@@ -11,7 +11,7 @@ use std::fmt::{Debug, Display};
 //      If there are arguments, they need to be safely inserted into the SQL Query with PgArguments
 pub trait BindArgs {
     // TODO: if any of these are to panic, this method should return a Result
-    fn bind(&self, args: &mut sqlx::postgres::PgArguments);
+    fn bind(&self, args: &mut sqlx::postgres::PgArguments) -> Result<(), anyhow::Error>;
     fn bind_len(&self) -> usize;
 }
 
@@ -60,18 +60,27 @@ pub enum SqlStatement<I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch> {
 impl<I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch> BindArgs for SqlStatement<I, U, F, P> {
     // Bind the Statement values to the query
     // (Ie - Struct{value: 1} or Enum::value(1)) -> iter.v / v -> PgArguments.add(v)
-    fn bind(&self, args: &mut sqlx::postgres::PgArguments) {
+    fn bind(&self, args: &mut sqlx::postgres::PgArguments) -> Result<(), anyhow::Error> {
         match self {
             Self::Select(v) => {
                 for ele in v {
-                    let _ = args.add(ele.to_string());
+                    args.add(ele.to_string()).map_err(|e| anyhow::anyhow!("{}", e))?;
                 }
             }
-            Self::InsertOne(v) => v.bind(args),
-            Self::InsertMany(v) => v.iter().for_each(|f| f.bind(args)),
-            Self::Update(v) => v.bind(args),
-            Self::Patch(v) => v.iter().for_each(|f| f.bind(args))
+            Self::InsertOne(v) => v.bind(args)?,
+            Self::InsertMany(v) => {
+                for f in v {
+                    f.bind(args)?;
+                }
+            }
+            Self::Update(v) => v.bind(args)?,
+            Self::Patch(v) => {
+                for f in v {
+                    f.bind(args)?;
+                }
+            }
         }
+        Ok(())
     }
 
     // Get the count of arg's that are to be bound
@@ -130,24 +139,25 @@ pub enum Filter {
 }
 
 impl BindArgs for Filter {
-    fn bind(&self, args: &mut sqlx::postgres::PgArguments) {
-        let _ = match self {
-            Self::Equals(v) => args.add(v),
-            Self::NotEquals(v) => args.add(v),
-            Self::In(v) => args.add(v),
-            Self::NotIn(v) => args.add(v),
-            Self::Like(v) => args.add(v),
-            Self::NotLike(v) => args.add(v),
-            Self::Ilike(v) => args.add(v),
-            Self::NotIlike(v) => args.add(v),
-            Self::StringIs(v) => args.add(v.to_owned()),
-            Self::StringIsNot(v) => args.add(v),
-            Self::Gt(v) => args.add(v),
-            Self::Gte(v) => args.add(v),
-            Self::Lt(v) => args.add(v),
-            Self::Lte(v) => args.add(v),
-            Self::IsNull => Ok(())
-        };
+    fn bind(&self, args: &mut sqlx::postgres::PgArguments) -> Result<(), anyhow::Error> {
+        match self {
+            Self::Equals(v) => args.add(v).map_err(|e| anyhow::anyhow!("{}", e))?,
+            Self::NotEquals(v) => args.add(v).map_err(|e| anyhow::anyhow!("{}", e))?,
+            Self::In(v) => args.add(v).map_err(|e| anyhow::anyhow!("{}", e))?,
+            Self::NotIn(v) => args.add(v).map_err(|e| anyhow::anyhow!("{}", e))?,
+            Self::Like(v) => args.add(v).map_err(|e| anyhow::anyhow!("{}", e))?,
+            Self::NotLike(v) => args.add(v).map_err(|e| anyhow::anyhow!("{}", e))?,
+            Self::Ilike(v) => args.add(v).map_err(|e| anyhow::anyhow!("{}", e))?,
+            Self::NotIlike(v) => args.add(v).map_err(|e| anyhow::anyhow!("{}", e))?,
+            Self::StringIs(v) => args.add(v.to_owned()).map_err(|e| anyhow::anyhow!("{}", e))?,
+            Self::StringIsNot(v) => args.add(v).map_err(|e| anyhow::anyhow!("{}", e))?,
+            Self::Gt(v) => args.add(v).map_err(|e| anyhow::anyhow!("{}", e))?,
+            Self::Gte(v) => args.add(v).map_err(|e| anyhow::anyhow!("{}", e))?,
+            Self::Lt(v) => args.add(v).map_err(|e| anyhow::anyhow!("{}", e))?,
+            Self::Lte(v) => args.add(v).map_err(|e| anyhow::anyhow!("{}", e))?,
+            Self::IsNull => {}
+        }
+        Ok(())
     }
     fn bind_len(&self) -> usize {
         match self {
@@ -229,7 +239,7 @@ impl<F: ToField> Debug for FilterOp<F> {
 }
 
 impl<F: ToField> BindArgs for FilterOp<F> {
-    fn bind(&self, args: &mut sqlx::postgres::PgArguments) {
+    fn bind(&self, args: &mut sqlx::postgres::PgArguments) -> Result<(), anyhow::Error> {
         match self {
             Self::Begin(_, w) => w.bind(args),
             Self::And(_, w) => w.bind(args),


### PR DESCRIPTION
## Issue
Closes #25 (recovered from stale PR #47)

## Summary
Changes `BindArgs::bind` to return `Result` instead of panicking, enabling proper error propagation throughout the repo builder execute path.

## Context for Reviewer
Safety improvement — removes panic paths in favor of Result-based error handling. Critical for production reliability.