### PR TITLE
[#22] feat: add offset/limit support to Builder

### DIFF
--- a/src/repo/build.rs
+++ b/src/repo/build.rs
@@ -292,13 +292,19 @@ pub trait ToSql<I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,> {
                     },)
                     .collect::<Result<Vec<_,>,>>()?
                     .join(",\n\t",);
-                let limit_offset = match (self.limit(), self.offset()) {
-                    (Some(l), Some(o)) => format!("\nLIMIT {l} OFFSET {o}"),
-                    (Some(l), None) => format!("\nLIMIT {l}"),
-                    (None, Some(o)) => format!("\nOFFSET {o}"),
-                    (None, None) => String::new(),
+                let limit_offset = match (self.limit(), self.offset(),) {
+                    (Some(l,), Some(o,),) => format!("\nLIMIT {l} OFFSET {o}"),
+                    (Some(l,), None,) => format!("\nLIMIT {l}"),
+                    (None, Some(o,),) => format!("\nOFFSET {o}"),
+                    (None, None,) => String::new(),
                 };
-                format!("SELECT\n\t{}\nFROM {}{}{};", &fields, self.schema(), where_str, limit_offset,)
+                format!(
+                    "SELECT\n\t{}\nFROM {}{}{};",
+                    &fields,
+                    self.schema(),
+                    where_str,
+                    limit_offset,
+                )
             }
             SqlStatement::InsertOne(row,) => {
                 let (mut fields, bind_idx_option,) = row.to_sql_parts();
@@ -637,7 +643,10 @@ mod tests {
     #[test]
     fn select_no_limit_no_offset() {
         let q = MockQuery::select("public.users", vec![Col("id",)],);
-        let sql = q.to_sql().expect("to_sql failed",);
+        let sql = match q.to_sql() {
+            std::result::Result::Ok(sql,) => sql,
+            Err(e,) => panic!("to_sql failed: {e:?}"),
+        };
         assert!(!sql.contains("LIMIT"), "unexpected LIMIT in: {sql}");
         assert!(!sql.contains("OFFSET"), "unexpected OFFSET in: {sql}");
     }
@@ -647,7 +656,10 @@ mod tests {
     fn select_limit_only() {
         let mut q = MockQuery::select("public.orders", vec![Col("id",)],);
         q.limit = Some(10,);
-        let sql = q.to_sql().expect("to_sql failed",);
+        let sql = match q.to_sql() {
+            std::result::Result::Ok(sql,) => sql,
+            Err(e,) => panic!("to_sql failed: {e:?}"),
+        };
         assert!(sql.contains("LIMIT 10"), "expected LIMIT 10 in:\n{sql}");
         assert!(!sql.contains("OFFSET"), "unexpected OFFSET in:\n{sql}");
     }
@@ -657,7 +669,10 @@ mod tests {
     fn select_offset_only() {
         let mut q = MockQuery::select("public.orders", vec![Col("id",)],);
         q.offset = Some(20,);
-        let sql = q.to_sql().expect("to_sql failed",);
+        let sql = match q.to_sql() {
+            std::result::Result::Ok(sql,) => sql,
+            Err(e,) => panic!("to_sql failed: {e:?}"),
+        };
         assert!(sql.contains("OFFSET 20"), "expected OFFSET 20 in:\n{sql}");
         assert!(!sql.contains("LIMIT"), "unexpected LIMIT in:\n{sql}");
     }
@@ -668,11 +683,11 @@ mod tests {
         let mut q = MockQuery::select("public.items", vec![Col("name",)],);
         q.limit = Some(5,);
         q.offset = Some(15,);
-        let sql = q.to_sql().expect("to_sql failed",);
-        assert!(
-            sql.contains("LIMIT 5 OFFSET 15"),
-            "expected 'LIMIT 5 OFFSET 15' in:\n{sql}"
-        );
+        let sql = match q.to_sql() {
+            std::result::Result::Ok(sql,) => sql,
+            Err(e,) => panic!("to_sql failed: {e:?}"),
+        };
+        assert!(sql.contains("LIMIT 5 OFFSET 15"), "expected 'LIMIT 5 OFFSET 15' in:\n{sql}");
     }
 
     /// `LIMIT/OFFSET` must appear after the WHERE clause, not before it.
@@ -682,13 +697,19 @@ mod tests {
         q.filters = vec![FilterOp::Begin(Col("active",), Filter::IsNull,)];
         q.limit = Some(3,);
         q.offset = Some(6,);
-        let sql = q.to_sql().expect("to_sql failed",);
-        let where_pos = sql.find("WHERE").expect("expected WHERE",);
-        let limit_pos = sql.find("LIMIT").expect("expected LIMIT",);
-        assert!(
-            limit_pos > where_pos,
-            "LIMIT must appear after WHERE — got:\n{sql}"
-        );
+        let sql = match q.to_sql() {
+            std::result::Result::Ok(sql,) => sql,
+            Err(e,) => panic!("to_sql failed: {e:?}"),
+        };
+        let where_pos = match sql.find("WHERE",) {
+            Some(pos,) => pos,
+            None => panic!("expected WHERE in: {sql}"),
+        };
+        let limit_pos = match sql.find("LIMIT",) {
+            Some(pos,) => pos,
+            None => panic!("expected LIMIT in: {sql}"),
+        };
+        assert!(limit_pos > where_pos, "LIMIT must appear after WHERE — got:\n{sql}");
     }
 
     /// Default `ToSql` trait implementations return `None` for limit/offset.

--- a/src/repo/build.rs
+++ b/src/repo/build.rs
@@ -52,16 +52,16 @@ use super::type_def::{Context, QueryAs, ToField, ToInsertRow, ToPatch, ToUpdateR
 /// - `F` — Field enum (generated as `Field`; drives SELECT column lists and WHERE clauses)
 /// - `P` — Patch type (generated as `PatchField`; updates ONLY the supplied fields —
 ///   prefer this over `update_many` for partial mutations)
-pub trait Build<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,>:
-    QueryAs + KeyAuths<F,>
+pub trait Build<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch>:
+    QueryAs + KeyAuths<F>
 {
     /// Construct a [`Builder`] pre-loaded with the given SQL statement variant.
     ///
     /// The builder is seeded with the schema-level key-auth filters returned by
     /// [`KeyAuths::keys`], so callers only need to add any additional WHERE conditions
     /// via [`Builder::filter`].
-    fn build(ctx: &C, statement: SqlStatement<I, U, F, P,>,) -> Builder<'_, C, Self, I, U, F, P,> {
-        Builder::<C, Self, I, U, F, P,> {
+    fn build(ctx: &C, statement: SqlStatement<I, U, F, P>) -> Builder<'_, C, Self, I, U, F, P> {
+        Builder::<C, Self, I, U, F, P> {
             statement,
             filters: Self::keys(),
             schema: Self::schema(),
@@ -69,7 +69,7 @@ pub trait Build<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPat
             query_as: PhantomData,
             returning: None,
             limit: None,
-            offset: None,
+            offset: None
         }
     }
     /// Return the fully-qualified SQL schema/table name for this domain type
@@ -83,8 +83,8 @@ pub trait Build<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPat
 /// produced by this domain's builder — typically a `sys_client` equality filter that
 /// scopes all DB access to the current tenant. The `#[schema]` macro generates a
 /// default (empty) implementation; override it to enforce row-level auth.
-pub trait KeyAuths<F: ToField,> {
-    fn keys() -> Vec<FilterOp<F,>,>;
+pub trait KeyAuths<F: ToField> {
+    fn keys() -> Vec<FilterOp<F>>;
 }
 
 /// High-level CRUD API for domain structs.
@@ -102,31 +102,31 @@ pub trait KeyAuths<F: ToField,> {
 /// Both require at least one `.filter(…)` before execution to prevent accidental full-table
 /// updates. Attempting to execute either without a filter returns an error.
 // TODO: the recs / rec needs to be borrowed -- this brings in lifetimes
-pub trait Interface<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,>:
-    Build<C, I, U, F, P,>
+pub trait Interface<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch>:
+    Build<C, I, U, F, P>
 {
     /// Build an `INSERT INTO … VALUES (…) RETURNING *` statement for a single row.
     ///
     /// `created_by` is automatically appended from the session user — callers do not
     /// need to set it on `rec`.
-    fn insert_one(ctx: &C, rec: I,) -> Builder<'_, C, Self, I, U, F, P,> {
-        Self::build(ctx, SqlStatement::<I, U, F, P,>::InsertOne(rec,),)
+    fn insert_one(ctx: &C, rec: I) -> Builder<'_, C, Self, I, U, F, P> {
+        Self::build(ctx, SqlStatement::<I, U, F, P>::InsertOne(rec))
     }
 
     /// Build an `INSERT INTO … VALUES …` statement for multiple rows.
     ///
     /// **Not yet implemented** — calling `.fetch_all()` on the returned builder will
     /// panic at runtime until bulk-insert support is added.
-    fn insert_many(ctx: &C, recs: Vec<I,>,) -> Builder<'_, C, Self, I, U, F, P,> {
-        Self::build(ctx, SqlStatement::<I, U, F, P,>::InsertMany(recs,),)
+    fn insert_many(ctx: &C, recs: Vec<I>) -> Builder<'_, C, Self, I, U, F, P> {
+        Self::build(ctx, SqlStatement::<I, U, F, P>::InsertMany(recs))
     }
 
     /// Build a `SELECT <fields> FROM <schema> [WHERE …]` statement.
     ///
     /// Pass `vec![Field::All]` to select every column, or enumerate specific [`ToField`]
     /// variants to project only those columns. Add WHERE conditions via `.filter(…)`.
-    fn select(ctx: &C, rec: Vec<F,>,) -> Builder<'_, C, Self, I, U, F, P,> {
-        Self::build(ctx, SqlStatement::<I, U, F, P,>::Select(rec,),)
+    fn select(ctx: &C, rec: Vec<F>) -> Builder<'_, C, Self, I, U, F, P> {
+        Self::build(ctx, SqlStatement::<I, U, F, P>::Select(rec))
     }
 
     /// Build a full-row `UPDATE … SET … FROM (VALUES …) RETURNING *` statement.
@@ -136,8 +136,8 @@ pub trait Interface<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: T
     /// all `Option` fields in `rec` are `None`.
     ///
     /// Prefer [`patch`](Self::patch) when only a subset of fields should change.
-    fn update_many(ctx: &C, rec: U,) -> Builder<'_, C, Self, I, U, F, P,> {
-        Self::build(ctx, SqlStatement::Update(rec,),)
+    fn update_many(ctx: &C, rec: U) -> Builder<'_, C, Self, I, U, F, P> {
+        Self::build(ctx, SqlStatement::Update(rec))
     }
 
     /// Build a partial `UPDATE … SET … FROM (VALUES …) RETURNING *` statement.
@@ -148,15 +148,15 @@ pub trait Interface<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: T
     /// [`update_many`](Self::update_many), which always writes every column.
     ///
     /// Requires at least one `.filter(…)` call and at least one element in `recs`.
-    fn patch(ctx: &C, recs: Vec<P,>,) -> Builder<'_, C, Self, I, U, F, P,> {
-        Self::build(ctx, SqlStatement::Patch(recs,),)
+    fn patch(ctx: &C, recs: Vec<P>) -> Builder<'_, C, Self, I, U, F, P> {
+        Self::build(ctx, SqlStatement::Patch(recs))
     }
 }
 
 // Blanket impl: every type that satisfies Build automatically gets Interface for free.
 // This means domain structs never need to manually implement Interface.
-impl<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch, B: Build<C, I, U, F, P,>,>
-    Interface<C, I, U, F, P,> for B
+impl<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch, B: Build<C, I, U, F, P>>
+    Interface<C, I, U, F, P> for B
 {
 }
 
@@ -172,95 +172,95 @@ pub struct Builder<
     I: ToInsertRow,
     U: ToUpdateRow,
     F: ToField,
-    P: ToPatch,
+    P: ToPatch
 > {
     /// The SQL operation variant (SELECT, INSERT, UPDATE, PATCH) with its payload.
-    statement: SqlStatement<I, U, F, P,>,
+    statement: SqlStatement<I, U, F, P>,
     /// Accumulated WHERE filters; seeded from [`KeyAuths::keys`] and extended by callers.
-    filters: Vec<FilterOp<F,>,>,
+    filters: Vec<FilterOp<F>>,
     /// Fully-qualified table/schema name (e.g. `"public.my_table"`).
     schema: String,
     ctx: &'a C,
-    query_as: PhantomData<fn() -> A,>,
-    returning: Option<Vec<F,>,>,
+    query_as: PhantomData<fn() -> A>,
+    returning: Option<Vec<F>>,
     /// Optional `LIMIT` clause — applied only to `SELECT` statements.
-    limit: Option<i64,>,
+    limit: Option<i64>,
     /// Optional `OFFSET` clause — applied only to `SELECT` statements.
-    offset: Option<i64,>,
+    offset: Option<i64>
 }
 
-impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,>
-    Builder<'_, C, A, I, U, F, P,>
+impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch>
+    Builder<'_, C, A, I, U, F, P>
 {
     /// Append additional WHERE filters to this builder.
     ///
     /// Filters are combined with the schema-level key-auth filters already present.
     /// Call this before any `fetch_*` / `execute` method.
-    pub fn filter(mut self, mut values: Vec<FilterOp<F,>,>,) -> Self {
-        self.filters.append(&mut values,);
+    pub fn filter(mut self, mut values: Vec<FilterOp<F>>) -> Self {
+        self.filters.append(&mut values);
         self
     }
     /// Override the default `RETURNING *` clause with a specific column list.
-    pub fn returning(mut self, values: Vec<F,>,) -> Self {
-        self.returning = Some(values,);
+    pub fn returning(mut self, values: Vec<F>) -> Self {
+        self.returning = Some(values);
         self
     }
 
     /// Set the maximum number of rows to return (`LIMIT n`).
     ///
     /// Only applied to `SELECT` statements; ignored for INSERT/UPDATE/PATCH.
-    pub fn limit(mut self, n: i64,) -> Self {
-        self.limit = Some(n,);
+    pub fn limit(mut self, n: i64) -> Self {
+        self.limit = Some(n);
         self
     }
 
     /// Skip the first `n` rows (`OFFSET n`).
     ///
     /// Only applied to `SELECT` statements; ignored for INSERT/UPDATE/PATCH.
-    pub fn offset(mut self, n: i64,) -> Self {
-        self.offset = Some(n,);
+    pub fn offset(mut self, n: i64) -> Self {
+        self.offset = Some(n);
         self
     }
 }
 
-impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,>
-    ContextAccessor for Builder<'_, C, A, I, U, F, P,>
+impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch> ContextAccessor
+    for Builder<'_, C, A, I, U, F, P>
 {
-    fn db_pool(&self,) -> &sqlx::PgPool {
+    fn db_pool(&self) -> &sqlx::PgPool {
         self.ctx.db_pool()
     }
-    fn session(&self,) -> &crate::session::Session {
+    fn session(&self) -> &crate::session::Session {
         self.ctx.session()
     }
-    fn session_user(&self,) -> &i32 {
+    fn session_user(&self) -> &i32 {
         self.ctx.session_user()
     }
 }
 
-impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,>
-    ToSql<I, U, F, P,> for Builder<'_, C, A, I, U, F, P,>
+impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch>
+    ToSql<I, U, F, P> for Builder<'_, C, A, I, U, F, P>
 {
-    fn statement(&self,) -> &SqlStatement<I, U, F, P,> {
+    fn statement(&self) -> &SqlStatement<I, U, F, P> {
         &self.statement
     }
-    fn schema(&self,) -> &String {
+    fn schema(&self) -> &String {
         &self.schema
     }
-    fn filters(&self,) -> &Vec<FilterOp<F,>,> {
+    fn filters(&self) -> &Vec<FilterOp<F>> {
         &self.filters
     }
-    fn limit(&self,) -> Option<i64,> {
+    fn limit(&self) -> Option<i64> {
         self.limit
     }
-    fn offset(&self,) -> Option<i64,> {
+    fn offset(&self) -> Option<i64> {
         self.offset
     }
 }
 
-impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,>
-    Execute<C, A, I, U, F, P,> for Builder<'_, C, A, I, U, F, P,>
+impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch>
+    Execute<C, A, I, U, F, P> for Builder<'_, C, A, I, U, F, P>
 where
-    Self: ToSql<I, U, F, P,>,
+    Self: ToSql<I, U, F, P>
 {
 }
 
@@ -268,35 +268,35 @@ where
 ///
 /// Separating SQL generation (`to_sql`) from execution ([`Execute`]) keeps the builder
 /// testable: call `to_sql()` to inspect the generated query without hitting the DB.
-pub trait ToSql<I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,> {
-    fn statement(&self,) -> &SqlStatement<I, U, F, P,>;
-    fn filters(&self,) -> &Vec<FilterOp<F,>,>;
-    fn schema(&self,) -> &String;
+pub trait ToSql<I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch> {
+    fn statement(&self) -> &SqlStatement<I, U, F, P>;
+    fn filters(&self) -> &Vec<FilterOp<F>>;
+    fn schema(&self) -> &String;
     /// Returns the `LIMIT` value if set. Default: `None`.
-    fn limit(&self,) -> Option<i64,> {
+    fn limit(&self) -> Option<i64> {
         None
     }
     /// Returns the `OFFSET` value if set. Default: `None`.
-    fn offset(&self,) -> Option<i64,> {
+    fn offset(&self) -> Option<i64> {
         None
     }
-    fn to_sql(&self,) -> Result<String,> {
+    fn to_sql(&self) -> Result<String> {
         Ok(match &self.statement() {
-            SqlStatement::Select(field_blocks,) => {
-                let where_str = sql_where(self.filters(), self.statement().bind_len(), None,);
+            SqlStatement::Select(field_blocks) => {
+                let where_str = sql_where(self.filters(), self.statement().bind_len(), None);
                 let fields = field_blocks
                     .iter()
-                    .map(|field| -> Result<String,> {
-                        let (mut str_value, _,) = field.to_sql_parts();
-                        str_value.pop().ok_or_else(|| anyhow!("cannot find binding index"),)
-                    },)
-                    .collect::<Result<Vec<_,>,>>()?
-                    .join(",\n\t",);
-                let limit_offset = match (self.limit(), self.offset(),) {
-                    (Some(l,), Some(o,),) => format!("\nLIMIT {l} OFFSET {o}"),
-                    (Some(l,), None,) => format!("\nLIMIT {l}"),
-                    (None, Some(o,),) => format!("\nOFFSET {o}"),
-                    (None, None,) => String::new(),
+                    .map(|field| -> Result<String> {
+                        let (mut str_value, _) = field.to_sql_parts();
+                        str_value.pop().ok_or_else(|| anyhow!("cannot find binding index"))
+                    })
+                    .collect::<Result<Vec<_>>>()?
+                    .join(",\n\t");
+                let limit_offset = match (self.limit(), self.offset()) {
+                    (Some(l), Some(o)) => format!("\nLIMIT {l} OFFSET {o}"),
+                    (Some(l), None) => format!("\nLIMIT {l}"),
+                    (None, Some(o)) => format!("\nOFFSET {o}"),
+                    (None, None) => String::new()
                 };
                 format!(
                     "SELECT\n\t{}\nFROM {}{}{};",
@@ -306,17 +306,17 @@ pub trait ToSql<I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,> {
                     limit_offset,
                 )
             }
-            SqlStatement::InsertOne(row,) => {
-                let (mut fields, bind_idx_option,) = row.to_sql_parts();
+            SqlStatement::InsertOne(row) => {
+                let (mut fields, bind_idx_option) = row.to_sql_parts();
                 let mut bind_idx =
-                    bind_idx_option.ok_or_else(|| anyhow!("cannot find binding index"),)?;
+                    bind_idx_option.ok_or_else(|| anyhow!("cannot find binding index"))?;
                 // Append `created_by` automatically — it is always sourced from the session
                 // user and must not be set by the caller.
-                fields.push("created_by".into(),);
+                fields.push("created_by".into());
                 let last_idx = bind_idx.len();
-                bind_idx.push(format!("${}", last_idx + 1),);
-                let fields_str = fields.join(",\n\t ",);
-                let bind_idx_str = bind_idx.join(", ",);
+                bind_idx.push(format!("${}", last_idx + 1));
+                let fields_str = fields.join(",\n\t ");
+                let bind_idx_str = bind_idx.join(", ");
                 format!(
                     "INSERT INTO {}\n\t(\n\t {}\n\t)\n\tVALUES ({})\nRETURNING *;",
                     self.schema(),
@@ -324,32 +324,29 @@ pub trait ToSql<I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,> {
                     bind_idx_str,
                 )
             }
-            SqlStatement::InsertMany(_,) => {
+            SqlStatement::InsertMany(_) => {
                 unimplemented!();
             }
             // SqlStatement::Update: full-row update — every column in UpdateRow is written.
             // Uses a VALUES CTE (_z_) to bind all fields as positional params safely.
             // The WHERE clause targets the original table alias (_x_) via sql_where.
-            SqlStatement::Update(row,) => {
-                let where_str = sql_where(
-                    self.filters(),
-                    self.statement().bind_len() + 1,
-                    Some("_x_".into(),),
-                );
-                let (mut fields, bind_idx_option,) = row.to_sql_parts();
+            SqlStatement::Update(row) => {
+                let where_str =
+                    sql_where(self.filters(), self.statement().bind_len() + 1, Some("_x_".into()));
+                let (mut fields, bind_idx_option) = row.to_sql_parts();
                 let mut bind_idx =
-                    bind_idx_option.ok_or_else(|| anyhow!("cannot find binding index"),)?;
+                    bind_idx_option.ok_or_else(|| anyhow!("cannot find binding index"))?;
                 // Append `updated_by` automatically — sourced from session user.
-                fields.push("updated_by".into(),);
+                fields.push("updated_by".into());
                 let last_idx = bind_idx.len();
-                bind_idx.push(format!("${}", last_idx + 1),);
-                let f = fields.join(",\n\t\t ",);
+                bind_idx.push(format!("${}", last_idx + 1));
+                let f = fields.join(",\n\t\t ");
                 let f_f = fields
                     .into_iter()
-                    .map(|f| format!("\n\t\t{f} = _z_.{f}"),)
-                    .collect::<Vec<_,>>()
-                    .join(", ",);
-                let v = bind_idx.join(", ",);
+                    .map(|f| format!("\n\t\t{f} = _z_.{f}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let v = bind_idx.join(", ");
                 let schema = self.schema();
                 format!(
                     "UPDATE {schema} _x_\n\tSET {f_f}\n\tFROM\n\t\t(VALUES ({v}))\n\tAS _z_ (\n\t\t {f}\n\t\t){where_str}\nRETURNING *;"
@@ -360,48 +357,44 @@ pub trait ToSql<I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,> {
             // SqlStatement::Update: callers specify exactly which columns change rather than
             // providing every column. Use patch() when you want to update 1–N fields without
             // overwriting the rest of the row.
-            SqlStatement::Patch(fields,) => {
-                let where_str = sql_where(
-                    self.filters(),
-                    self.statement().bind_len() + 1,
-                    Some("_x_".into(),),
-                );
-                let (mut fields, _,) = concat_sql_parts(
-                    fields.iter().map(|f| f.to_sql_parts(),).collect::<Vec<_,>>(),
-                );
+            SqlStatement::Patch(fields) => {
+                let where_str =
+                    sql_where(self.filters(), self.statement().bind_len() + 1, Some("_x_".into()));
+                let (mut fields, _) =
+                    concat_sql_parts(fields.iter().map(|f| f.to_sql_parts()).collect::<Vec<_>>());
                 let mut bind_idx =
-                    (0..fields.len()).map(|i| format!("${:?}", i + 1),).collect::<Vec<_,>>();
+                    (0..fields.len()).map(|i| format!("${:?}", i + 1)).collect::<Vec<_>>();
                 // Append `updated_by` — always sourced from session user, not from PatchField.
-                fields.push("updated_by".into(),);
+                fields.push("updated_by".into());
                 let last_idx = bind_idx.len();
-                bind_idx.push(format!("${}", last_idx + 1),);
-                let f = fields.join(",\n\t\t ",);
+                bind_idx.push(format!("${}", last_idx + 1));
+                let f = fields.join(",\n\t\t ");
                 let f_f = fields
                     .into_iter()
-                    .map(|f| format!("\n\t\t{f} = _z_.{f}"),)
-                    .collect::<Vec<_,>>()
-                    .join(", ",);
-                let v = bind_idx.join(", ",);
+                    .map(|f| format!("\n\t\t{f} = _z_.{f}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let v = bind_idx.join(", ");
                 let schema = self.schema();
                 format!(
                     "UPDATE {schema} _x_\n\tSET {f_f}\n\tFROM\n\t\t(VALUES ({v}))\n\tAS _z_ (\n\t\t {f}\n\t\t){where_str}\nRETURNING *;"
                 )
             }
-        },)
+        })
     }
-    fn args(&self, session_user: &i32,) -> sqlx::postgres::PgArguments {
+    fn args(&self, session_user: &i32) -> sqlx::postgres::PgArguments {
         let mut args = sqlx::postgres::PgArguments::default();
         match self.statement() {
-            SqlStatement::Select(_,) => {}
+            SqlStatement::Select(_) => {}
             _ => {
-                self.statement().bind(&mut args,);
+                self.statement().bind(&mut args);
                 // Always bind session_user last for INSERT (created_by) and UPDATE/PATCH
                 // (updated_by). The placeholder is the final positional param in to_sql().
-                let _ = args.add(session_user,);
+                let _ = args.add(session_user);
             }
         };
         for w in self.filters().iter() {
-            w.bind(&mut args,);
+            w.bind(&mut args);
         }
         args
     }
@@ -412,29 +405,29 @@ pub trait ToSql<I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,> {
 /// Implemented automatically for any [`Builder`] that also implements [`ToSql`].
 /// The `fetch_all` method is the primary entry point for most callers; `execute` is
 /// for fire-and-forget mutations that don't need returned rows.
-pub trait Execute<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,>:
-    ToSql<I, U, F, P,> + ContextAccessor
+pub trait Execute<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch>:
+    ToSql<I, U, F, P> + ContextAccessor
 {
     /// Execute the statement without returning rows (e.g. a side-effect-only mutation).
-    fn execute(&self, _ctx: &C,) -> impl std::future::Future<Output = anyhow::Result<(),>,> + Send
+    fn execute(&self, _ctx: &C) -> impl std::future::Future<Output = anyhow::Result<()>> + Send
     where
-        Self: Sync,
+        Self: Sync
     {
         async { todo!() }
     }
     fn fetch_optional(
         &self,
-        _ctx: &C,
-    ) -> impl std::future::Future<Output = anyhow::Result<Option<A,>,>,> + Send
+        _ctx: &C
+    ) -> impl std::future::Future<Output = anyhow::Result<Option<A>>> + Send
     where
-        Self: Sync,
+        Self: Sync
     {
         async { todo!() }
     }
     /// Execute and return exactly one row, erroring if zero or more than one row is returned.
-    fn fetch_one(&self, _ctx: &C,) -> impl std::future::Future<Output = anyhow::Result<A,>,> + Send
+    fn fetch_one(&self, _ctx: &C) -> impl std::future::Future<Output = anyhow::Result<A>> + Send
     where
-        Self: Sync,
+        Self: Sync
     {
         async { todo!() }
     }
@@ -445,24 +438,24 @@ pub trait Execute<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToF
     ///
     /// Pass a `&mut Transaction` to participate in the caller's transaction, or the pool
     /// directly for auto-commit behaviour.
-    fn fetch_all<'c,>(
+    fn fetch_all<'c>(
         &self,
-        exec: impl Executor<'c, Database = Postgres,>,
-    ) -> impl std::future::Future<Output = anyhow::Result<Vec<A,>,>,> + Send
+        exec: impl Executor<'c, Database = Postgres>
+    ) -> impl std::future::Future<Output = anyhow::Result<Vec<A>>> + Send
     where
-        Self: Sync + Send,
+        Self: Sync + Send
     {
         async move {
             self.authenticate_request()?;
             let sql = self.to_sql()?;
-            let req = sqlx::query_as_with::<'_, sqlx::Postgres, A, sqlx::postgres::PgArguments,>(
+            let req = sqlx::query_as_with::<'_, sqlx::Postgres, A, sqlx::postgres::PgArguments>(
                 &sql,
-                self.args(self.session_user(),),
+                self.args(self.session_user())
             );
-            let res: anyhow::Result<Vec<A,>,> = req
-                .fetch_all(exec,)
+            let res: anyhow::Result<Vec<A>> = req
+                .fetch_all(exec)
                 .await
-                .map_err(|e| anyhow::anyhow!("Unable to fetch all: {}", e),);
+                .map_err(|e| anyhow::anyhow!("Unable to fetch all: {}", e));
             res
         }
     }
@@ -472,36 +465,36 @@ pub trait Execute<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToF
     ///   and at least one non-empty field (prevents no-op updates).
     /// - `Select`: requires exactly one field-block when using `fetch_all`; use
     ///   `fetch_all_raw` for multi-column projections.
-    fn authenticate_request(&self,) -> Result<(),> {
+    fn authenticate_request(&self) -> Result<()> {
         match self.statement() {
-            SqlStatement::Update(_,) | SqlStatement::Patch(_,) => {
+            SqlStatement::Update(_) | SqlStatement::Patch(_) => {
                 if self.filters().is_empty() {
-                    return Err(anyhow!("Unable to Update/Patch without filters"),);
+                    return Err(anyhow!("Unable to Update/Patch without filters"));
                 }
                 if self.statement().bind_len() < 1 {
-                    return Err(anyhow!("Unable to Update/Patch with all fields empty"),);
+                    return Err(anyhow!("Unable to Update/Patch with all fields empty"));
                 }
-                Ok((),)
+                Ok(())
             }
-            SqlStatement::Select(field_blocks,) => {
+            SqlStatement::Select(field_blocks) => {
                 if field_blocks.len() != 1 {
                     return Err(anyhow!(
                         "Unable to use the fetch_all method while choosing which fields to return. Use the fetch_all_raw() method."
-                    ),);
+                    ));
                 }
-                Ok((),)
+                Ok(())
             }
-            _ => Ok((),),
+            _ => Ok(())
         }
     }
 }
 
-impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,> Debug
-    for Builder<'_, C, A, I, U, F, P,>
+impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch> Debug
+    for Builder<'_, C, A, I, U, F, P>
 where
-    Self: ToSql<I, U, F, P,>,
+    Self: ToSql<I, U, F, P>
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_,>,) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "\n{}\n\tSQL\n{}\n\n", "*".repeat(18), "*".repeat(18),)?;
         write!(f, "{}", self.to_sql().map_err(|_| std::fmt::Error)?)?;
         let mut bind_len = self.statement.bind_len();
@@ -511,10 +504,10 @@ where
             write!(f, "\n\n{}\n{}BINDINGS\n{}\n", "*".repeat(18), " ".repeat(5), "*".repeat(18),)?;
         }
         if !bind_len.is_zero() {
-            self.statement.fmt(f,)?;
+            self.statement.fmt(f)?;
         }
         match self.statement {
-            SqlStatement::Select(_,) => writeln!(f),
+            SqlStatement::Select(_) => writeln!(f),
             _ => {
                 bind_len += 1;
                 return write!(f, "\n\t${} = [session_user]\n", bind_len);
@@ -522,11 +515,11 @@ where
         }?;
 
         let mut filter_has_bindings = false;
-        let mut filter_bindings_string = String::from("",);
+        let mut filter_bindings_string = String::from("");
 
-        for (i, filter,) in self.filters.iter().enumerate() {
+        for (i, filter) in self.filters.iter().enumerate() {
             match filter {
-                FilterOp::And(_c, v,) | FilterOp::Or(_c, v,) | FilterOp::Begin(_c, v,) => match v {
+                FilterOp::And(_c, v) | FilterOp::Or(_c, v) | FilterOp::Begin(_c, v) => match v {
                     Filter::IsNull => {}
                     _ => {
                         _has_bindings = true;
@@ -535,9 +528,9 @@ where
                             "\n\t${} = {:?}",
                             i + bind_len + 1,
                             &filter
-                        ),);
+                        ));
                     }
-                },
+                }
             }
         }
         if filter_has_bindings {
@@ -560,7 +553,7 @@ where
 
         write!(f, "\n{}", "*".repeat(18))?;
         write!(f, "\n{}\n", "*".repeat(18))?;
-        std::fmt::Result::Ok((),)
+        std::fmt::Result::Ok(())
     }
 }
 
@@ -573,26 +566,26 @@ mod tests {
     // ── Minimal stubs ────────────────────────────────────────────────────────
 
     /// A stub column that satisfies `ToField` (`ToSqlParts + Display`).
-    #[derive(Debug, Clone,)]
-    struct Col(&'static str,);
+    #[derive(Debug, Clone)]
+    struct Col(&'static str);
 
     impl fmt::Display for Col {
-        fn fmt(&self, f: &mut fmt::Formatter<'_,>,) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "{}", self.0)
         }
     }
 
     impl crate::repo::map_util::ToSqlParts for Col {
-        fn to_sql_parts(&self,) -> AsSqlParts {
+        fn to_sql_parts(&self) -> AsSqlParts {
             // SELECT branch pops the last element as the binding index placeholder;
             // we push a dummy so the pop succeeds and the real name is kept.
-            (vec![self.0.to_string(), String::new()], None,)
+            (vec![self.0.to_string(), String::new()], None)
         }
     }
 
     impl BindArgs for Col {
-        fn bind(&self, _args: &mut sqlx::postgres::PgArguments,) {}
-        fn bind_len(&self,) -> usize {
+        fn bind(&self, _args: &mut sqlx::postgres::PgArguments) {}
+        fn bind_len(&self) -> usize {
             0
         }
     }
@@ -600,39 +593,39 @@ mod tests {
     // ── Struct that lets us exercise `ToSql::to_sql` directly ────────────────
 
     struct MockQuery {
-        statement: SqlStatement<Col, Col, Col, Col,>,
-        filters: Vec<FilterOp<Col,>,>,
+        statement: SqlStatement<Col, Col, Col, Col>,
+        filters: Vec<FilterOp<Col>>,
         schema: String,
-        limit: Option<i64,>,
-        offset: Option<i64,>,
+        limit: Option<i64>,
+        offset: Option<i64>
     }
 
     impl MockQuery {
-        fn select(schema: &str, cols: Vec<Col,>,) -> Self {
+        fn select(schema: &str, cols: Vec<Col>) -> Self {
             Self {
-                statement: SqlStatement::Select(cols,),
+                statement: SqlStatement::Select(cols),
                 filters: vec![],
                 schema: schema.to_string(),
                 limit: None,
-                offset: None,
+                offset: None
             }
         }
     }
 
-    impl ToSql<Col, Col, Col, Col,> for MockQuery {
-        fn statement(&self,) -> &SqlStatement<Col, Col, Col, Col,> {
+    impl ToSql<Col, Col, Col, Col> for MockQuery {
+        fn statement(&self) -> &SqlStatement<Col, Col, Col, Col> {
             &self.statement
         }
-        fn filters(&self,) -> &Vec<FilterOp<Col,>,> {
+        fn filters(&self) -> &Vec<FilterOp<Col>> {
             &self.filters
         }
-        fn schema(&self,) -> &String {
+        fn schema(&self) -> &String {
             &self.schema
         }
-        fn limit(&self,) -> Option<i64,> {
+        fn limit(&self) -> Option<i64> {
             self.limit
         }
-        fn offset(&self,) -> Option<i64,> {
+        fn offset(&self) -> Option<i64> {
             self.offset
         }
     }
@@ -642,10 +635,10 @@ mod tests {
     /// A plain SELECT should contain neither LIMIT nor OFFSET.
     #[test]
     fn select_no_limit_no_offset() {
-        let q = MockQuery::select("public.users", vec![Col("id",)],);
+        let q = MockQuery::select("public.users", vec![Col("id")]);
         let sql = match q.to_sql() {
-            std::result::Result::Ok(sql,) => sql,
-            Err(e,) => panic!("to_sql failed: {e:?}"),
+            std::result::Result::Ok(sql) => sql,
+            Err(e) => panic!("to_sql failed: {e:?}")
         };
         assert!(!sql.contains("LIMIT"), "unexpected LIMIT in: {sql}");
         assert!(!sql.contains("OFFSET"), "unexpected OFFSET in: {sql}");
@@ -654,11 +647,11 @@ mod tests {
     /// `limit` alone should append `LIMIT n` after WHERE (or table name if no WHERE).
     #[test]
     fn select_limit_only() {
-        let mut q = MockQuery::select("public.orders", vec![Col("id",)],);
-        q.limit = Some(10,);
+        let mut q = MockQuery::select("public.orders", vec![Col("id")]);
+        q.limit = Some(10);
         let sql = match q.to_sql() {
-            std::result::Result::Ok(sql,) => sql,
-            Err(e,) => panic!("to_sql failed: {e:?}"),
+            std::result::Result::Ok(sql) => sql,
+            Err(e) => panic!("to_sql failed: {e:?}")
         };
         assert!(sql.contains("LIMIT 10"), "expected LIMIT 10 in:\n{sql}");
         assert!(!sql.contains("OFFSET"), "unexpected OFFSET in:\n{sql}");
@@ -667,11 +660,11 @@ mod tests {
     /// `offset` alone should append `OFFSET n` (without a preceding LIMIT).
     #[test]
     fn select_offset_only() {
-        let mut q = MockQuery::select("public.orders", vec![Col("id",)],);
-        q.offset = Some(20,);
+        let mut q = MockQuery::select("public.orders", vec![Col("id")]);
+        q.offset = Some(20);
         let sql = match q.to_sql() {
-            std::result::Result::Ok(sql,) => sql,
-            Err(e,) => panic!("to_sql failed: {e:?}"),
+            std::result::Result::Ok(sql) => sql,
+            Err(e) => panic!("to_sql failed: {e:?}")
         };
         assert!(sql.contains("OFFSET 20"), "expected OFFSET 20 in:\n{sql}");
         assert!(!sql.contains("LIMIT"), "unexpected LIMIT in:\n{sql}");
@@ -680,12 +673,12 @@ mod tests {
     /// Both limit and offset should produce `LIMIT n OFFSET m` in that order.
     #[test]
     fn select_limit_and_offset() {
-        let mut q = MockQuery::select("public.items", vec![Col("name",)],);
-        q.limit = Some(5,);
-        q.offset = Some(15,);
+        let mut q = MockQuery::select("public.items", vec![Col("name")]);
+        q.limit = Some(5);
+        q.offset = Some(15);
         let sql = match q.to_sql() {
-            std::result::Result::Ok(sql,) => sql,
-            Err(e,) => panic!("to_sql failed: {e:?}"),
+            std::result::Result::Ok(sql) => sql,
+            Err(e) => panic!("to_sql failed: {e:?}")
         };
         assert!(sql.contains("LIMIT 5 OFFSET 15"), "expected 'LIMIT 5 OFFSET 15' in:\n{sql}");
     }
@@ -693,21 +686,21 @@ mod tests {
     /// `LIMIT/OFFSET` must appear after the WHERE clause, not before it.
     #[test]
     fn limit_offset_after_where_clause() {
-        let mut q = MockQuery::select("public.events", vec![Col("id",)],);
-        q.filters = vec![FilterOp::Begin(Col("active",), Filter::IsNull,)];
-        q.limit = Some(3,);
-        q.offset = Some(6,);
+        let mut q = MockQuery::select("public.events", vec![Col("id")]);
+        q.filters = vec![FilterOp::Begin(Col("active"), Filter::IsNull)];
+        q.limit = Some(3);
+        q.offset = Some(6);
         let sql = match q.to_sql() {
-            std::result::Result::Ok(sql,) => sql,
-            Err(e,) => panic!("to_sql failed: {e:?}"),
+            std::result::Result::Ok(sql) => sql,
+            Err(e) => panic!("to_sql failed: {e:?}")
         };
-        let where_pos = match sql.find("WHERE",) {
-            Some(pos,) => pos,
-            None => panic!("expected WHERE in: {sql}"),
+        let where_pos = match sql.find("WHERE") {
+            Some(pos) => pos,
+            None => panic!("expected WHERE in: {sql}")
         };
-        let limit_pos = match sql.find("LIMIT",) {
-            Some(pos,) => pos,
-            None => panic!("expected LIMIT in: {sql}"),
+        let limit_pos = match sql.find("LIMIT") {
+            Some(pos) => pos,
+            None => panic!("expected LIMIT in: {sql}")
         };
         assert!(limit_pos > where_pos, "LIMIT must appear after WHERE — got:\n{sql}");
     }
@@ -715,7 +708,7 @@ mod tests {
     /// Default `ToSql` trait implementations return `None` for limit/offset.
     #[test]
     fn tosql_trait_defaults_return_none() {
-        let q = MockQuery::select("t", vec![Col("x",)],);
+        let q = MockQuery::select("t", vec![Col("x")]);
         // We override both, so verify the overrides work correctly.
         assert_eq!(q.limit(), None);
         assert_eq!(q.offset(), None);

--- a/src/repo/build.rs
+++ b/src/repo/build.rs
@@ -52,22 +52,24 @@ use super::type_def::{Context, QueryAs, ToField, ToInsertRow, ToPatch, ToUpdateR
 /// - `F` — Field enum (generated as `Field`; drives SELECT column lists and WHERE clauses)
 /// - `P` — Patch type (generated as `PatchField`; updates ONLY the supplied fields —
 ///   prefer this over `update_many` for partial mutations)
-pub trait Build<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch>:
-    QueryAs + KeyAuths<F>
+pub trait Build<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,>:
+    QueryAs + KeyAuths<F,>
 {
     /// Construct a [`Builder`] pre-loaded with the given SQL statement variant.
     ///
     /// The builder is seeded with the schema-level key-auth filters returned by
     /// [`KeyAuths::keys`], so callers only need to add any additional WHERE conditions
     /// via [`Builder::filter`].
-    fn build(ctx: &C, statement: SqlStatement<I, U, F, P>) -> Builder<'_, C, Self, I, U, F, P> {
-        Builder::<C, Self, I, U, F, P> {
+    fn build(ctx: &C, statement: SqlStatement<I, U, F, P,>,) -> Builder<'_, C, Self, I, U, F, P,> {
+        Builder::<C, Self, I, U, F, P,> {
             statement,
             filters: Self::keys(),
             schema: Self::schema(),
             ctx,
             query_as: PhantomData,
-            returning: None
+            returning: None,
+            limit: None,
+            offset: None,
         }
     }
     /// Return the fully-qualified SQL schema/table name for this domain type
@@ -81,8 +83,8 @@ pub trait Build<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPat
 /// produced by this domain's builder — typically a `sys_client` equality filter that
 /// scopes all DB access to the current tenant. The `#[schema]` macro generates a
 /// default (empty) implementation; override it to enforce row-level auth.
-pub trait KeyAuths<F: ToField> {
-    fn keys() -> Vec<FilterOp<F>>;
+pub trait KeyAuths<F: ToField,> {
+    fn keys() -> Vec<FilterOp<F,>,>;
 }
 
 /// High-level CRUD API for domain structs.
@@ -100,31 +102,31 @@ pub trait KeyAuths<F: ToField> {
 /// Both require at least one `.filter(…)` before execution to prevent accidental full-table
 /// updates. Attempting to execute either without a filter returns an error.
 // TODO: the recs / rec needs to be borrowed -- this brings in lifetimes
-pub trait Interface<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch>:
-    Build<C, I, U, F, P>
+pub trait Interface<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,>:
+    Build<C, I, U, F, P,>
 {
     /// Build an `INSERT INTO … VALUES (…) RETURNING *` statement for a single row.
     ///
     /// `created_by` is automatically appended from the session user — callers do not
     /// need to set it on `rec`.
-    fn insert_one(ctx: &C, rec: I) -> Builder<'_, C, Self, I, U, F, P> {
-        Self::build(ctx, SqlStatement::<I, U, F, P>::InsertOne(rec))
+    fn insert_one(ctx: &C, rec: I,) -> Builder<'_, C, Self, I, U, F, P,> {
+        Self::build(ctx, SqlStatement::<I, U, F, P,>::InsertOne(rec,),)
     }
 
     /// Build an `INSERT INTO … VALUES …` statement for multiple rows.
     ///
     /// **Not yet implemented** — calling `.fetch_all()` on the returned builder will
     /// panic at runtime until bulk-insert support is added.
-    fn insert_many(ctx: &C, recs: Vec<I>) -> Builder<'_, C, Self, I, U, F, P> {
-        Self::build(ctx, SqlStatement::<I, U, F, P>::InsertMany(recs))
+    fn insert_many(ctx: &C, recs: Vec<I,>,) -> Builder<'_, C, Self, I, U, F, P,> {
+        Self::build(ctx, SqlStatement::<I, U, F, P,>::InsertMany(recs,),)
     }
 
     /// Build a `SELECT <fields> FROM <schema> [WHERE …]` statement.
     ///
     /// Pass `vec![Field::All]` to select every column, or enumerate specific [`ToField`]
     /// variants to project only those columns. Add WHERE conditions via `.filter(…)`.
-    fn select(ctx: &C, rec: Vec<F>) -> Builder<'_, C, Self, I, U, F, P> {
-        Self::build(ctx, SqlStatement::<I, U, F, P>::Select(rec))
+    fn select(ctx: &C, rec: Vec<F,>,) -> Builder<'_, C, Self, I, U, F, P,> {
+        Self::build(ctx, SqlStatement::<I, U, F, P,>::Select(rec,),)
     }
 
     /// Build a full-row `UPDATE … SET … FROM (VALUES …) RETURNING *` statement.
@@ -134,8 +136,8 @@ pub trait Interface<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: T
     /// all `Option` fields in `rec` are `None`.
     ///
     /// Prefer [`patch`](Self::patch) when only a subset of fields should change.
-    fn update_many(ctx: &C, rec: U) -> Builder<'_, C, Self, I, U, F, P> {
-        Self::build(ctx, SqlStatement::Update(rec))
+    fn update_many(ctx: &C, rec: U,) -> Builder<'_, C, Self, I, U, F, P,> {
+        Self::build(ctx, SqlStatement::Update(rec,),)
     }
 
     /// Build a partial `UPDATE … SET … FROM (VALUES …) RETURNING *` statement.
@@ -146,15 +148,15 @@ pub trait Interface<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: T
     /// [`update_many`](Self::update_many), which always writes every column.
     ///
     /// Requires at least one `.filter(…)` call and at least one element in `recs`.
-    fn patch(ctx: &C, recs: Vec<P>) -> Builder<'_, C, Self, I, U, F, P> {
-        Self::build(ctx, SqlStatement::Patch(recs))
+    fn patch(ctx: &C, recs: Vec<P,>,) -> Builder<'_, C, Self, I, U, F, P,> {
+        Self::build(ctx, SqlStatement::Patch(recs,),)
     }
 }
 
 // Blanket impl: every type that satisfies Build automatically gets Interface for free.
 // This means domain structs never need to manually implement Interface.
-impl<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch, B: Build<C, I, U, F, P>>
-    Interface<C, I, U, F, P> for B
+impl<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch, B: Build<C, I, U, F, P,>,>
+    Interface<C, I, U, F, P,> for B
 {
 }
 
@@ -162,7 +164,7 @@ impl<C: Context, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch, B: Buil
 ///
 /// Created by [`Build::build`] (or the [`Interface`] helpers) and consumed by the
 /// [`Execute`] methods (`fetch_all`, `fetch_one`, etc.). Chain [`Builder::filter`] and
-/// [`Builder::returning`] before executing.
+/// [`Builder::returning`], [`Builder::limit`], and [`Builder::offset`] before executing.
 pub struct Builder<
     'a,
     C: Context,
@@ -170,69 +172,95 @@ pub struct Builder<
     I: ToInsertRow,
     U: ToUpdateRow,
     F: ToField,
-    P: ToPatch
+    P: ToPatch,
 > {
     /// The SQL operation variant (SELECT, INSERT, UPDATE, PATCH) with its payload.
-    statement: SqlStatement<I, U, F, P>,
+    statement: SqlStatement<I, U, F, P,>,
     /// Accumulated WHERE filters; seeded from [`KeyAuths::keys`] and extended by callers.
-    filters: Vec<FilterOp<F>>,
+    filters: Vec<FilterOp<F,>,>,
     /// Fully-qualified table/schema name (e.g. `"public.my_table"`).
     schema: String,
     ctx: &'a C,
-    query_as: PhantomData<fn() -> A>,
-    returning: Option<Vec<F>>
+    query_as: PhantomData<fn() -> A,>,
+    returning: Option<Vec<F,>,>,
+    /// Optional `LIMIT` clause — applied only to `SELECT` statements.
+    limit: Option<i64,>,
+    /// Optional `OFFSET` clause — applied only to `SELECT` statements.
+    offset: Option<i64,>,
 }
 
-impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch>
-    Builder<'_, C, A, I, U, F, P>
+impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,>
+    Builder<'_, C, A, I, U, F, P,>
 {
     /// Append additional WHERE filters to this builder.
     ///
     /// Filters are combined with the schema-level key-auth filters already present.
     /// Call this before any `fetch_*` / `execute` method.
-    pub fn filter(mut self, mut values: Vec<FilterOp<F>>) -> Self {
-        self.filters.append(&mut values);
+    pub fn filter(mut self, mut values: Vec<FilterOp<F,>,>,) -> Self {
+        self.filters.append(&mut values,);
         self
     }
     /// Override the default `RETURNING *` clause with a specific column list.
-    pub fn returning(mut self, values: Vec<F>) -> Self {
-        self.returning = Some(values);
+    pub fn returning(mut self, values: Vec<F,>,) -> Self {
+        self.returning = Some(values,);
+        self
+    }
+
+    /// Set the maximum number of rows to return (`LIMIT n`).
+    ///
+    /// Only applied to `SELECT` statements; ignored for INSERT/UPDATE/PATCH.
+    pub fn limit(mut self, n: i64,) -> Self {
+        self.limit = Some(n,);
+        self
+    }
+
+    /// Skip the first `n` rows (`OFFSET n`).
+    ///
+    /// Only applied to `SELECT` statements; ignored for INSERT/UPDATE/PATCH.
+    pub fn offset(mut self, n: i64,) -> Self {
+        self.offset = Some(n,);
         self
     }
 }
 
-impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch> ContextAccessor
-    for Builder<'_, C, A, I, U, F, P>
+impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,>
+    ContextAccessor for Builder<'_, C, A, I, U, F, P,>
 {
-    fn db_pool(&self) -> &sqlx::PgPool {
+    fn db_pool(&self,) -> &sqlx::PgPool {
         self.ctx.db_pool()
     }
-    fn session(&self) -> &crate::session::Session {
+    fn session(&self,) -> &crate::session::Session {
         self.ctx.session()
     }
-    fn session_user(&self) -> &i32 {
+    fn session_user(&self,) -> &i32 {
         self.ctx.session_user()
     }
 }
 
-impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch>
-    ToSql<I, U, F, P> for Builder<'_, C, A, I, U, F, P>
+impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,>
+    ToSql<I, U, F, P,> for Builder<'_, C, A, I, U, F, P,>
 {
-    fn statement(&self) -> &SqlStatement<I, U, F, P> {
+    fn statement(&self,) -> &SqlStatement<I, U, F, P,> {
         &self.statement
     }
-    fn schema(&self) -> &String {
+    fn schema(&self,) -> &String {
         &self.schema
     }
-    fn filters(&self) -> &Vec<FilterOp<F>> {
+    fn filters(&self,) -> &Vec<FilterOp<F,>,> {
         &self.filters
+    }
+    fn limit(&self,) -> Option<i64,> {
+        self.limit
+    }
+    fn offset(&self,) -> Option<i64,> {
+        self.offset
     }
 }
 
-impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch>
-    Execute<C, A, I, U, F, P> for Builder<'_, C, A, I, U, F, P>
+impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,>
+    Execute<C, A, I, U, F, P,> for Builder<'_, C, A, I, U, F, P,>
 where
-    Self: ToSql<I, U, F, P>
+    Self: ToSql<I, U, F, P,>,
 {
 }
 
@@ -240,35 +268,49 @@ where
 ///
 /// Separating SQL generation (`to_sql`) from execution ([`Execute`]) keeps the builder
 /// testable: call `to_sql()` to inspect the generated query without hitting the DB.
-pub trait ToSql<I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch> {
-    fn statement(&self) -> &SqlStatement<I, U, F, P>;
-    fn filters(&self) -> &Vec<FilterOp<F>>;
-    fn schema(&self) -> &String;
-    fn to_sql(&self) -> Result<String> {
+pub trait ToSql<I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,> {
+    fn statement(&self,) -> &SqlStatement<I, U, F, P,>;
+    fn filters(&self,) -> &Vec<FilterOp<F,>,>;
+    fn schema(&self,) -> &String;
+    /// Returns the `LIMIT` value if set. Default: `None`.
+    fn limit(&self,) -> Option<i64,> {
+        None
+    }
+    /// Returns the `OFFSET` value if set. Default: `None`.
+    fn offset(&self,) -> Option<i64,> {
+        None
+    }
+    fn to_sql(&self,) -> Result<String,> {
         Ok(match &self.statement() {
-            SqlStatement::Select(field_blocks) => {
-                let where_str = sql_where(self.filters(), self.statement().bind_len(), None);
+            SqlStatement::Select(field_blocks,) => {
+                let where_str = sql_where(self.filters(), self.statement().bind_len(), None,);
                 let fields = field_blocks
                     .iter()
-                    .map(|field| -> Result<String> {
-                        let (mut str_value, _) = field.to_sql_parts();
-                        str_value.pop().ok_or_else(|| anyhow!("cannot find binding index"))
-                    })
-                    .collect::<Result<Vec<_>>>()?
-                    .join(",\n\t");
-                format!("SELECT\n\t{}\nFROM {}{};", &fields, self.schema(), where_str,)
+                    .map(|field| -> Result<String,> {
+                        let (mut str_value, _,) = field.to_sql_parts();
+                        str_value.pop().ok_or_else(|| anyhow!("cannot find binding index"),)
+                    },)
+                    .collect::<Result<Vec<_,>,>>()?
+                    .join(",\n\t",);
+                let limit_offset = match (self.limit(), self.offset()) {
+                    (Some(l), Some(o)) => format!("\nLIMIT {l} OFFSET {o}"),
+                    (Some(l), None) => format!("\nLIMIT {l}"),
+                    (None, Some(o)) => format!("\nOFFSET {o}"),
+                    (None, None) => String::new(),
+                };
+                format!("SELECT\n\t{}\nFROM {}{}{};", &fields, self.schema(), where_str, limit_offset,)
             }
-            SqlStatement::InsertOne(row) => {
-                let (mut fields, bind_idx_option) = row.to_sql_parts();
+            SqlStatement::InsertOne(row,) => {
+                let (mut fields, bind_idx_option,) = row.to_sql_parts();
                 let mut bind_idx =
-                    bind_idx_option.ok_or_else(|| anyhow!("cannot find binding index"))?;
+                    bind_idx_option.ok_or_else(|| anyhow!("cannot find binding index"),)?;
                 // Append `created_by` automatically — it is always sourced from the session
                 // user and must not be set by the caller.
-                fields.push("created_by".into());
+                fields.push("created_by".into(),);
                 let last_idx = bind_idx.len();
-                bind_idx.push(format!("${}", last_idx + 1));
-                let fields_str = fields.join(",\n\t ");
-                let bind_idx_str = bind_idx.join(", ");
+                bind_idx.push(format!("${}", last_idx + 1),);
+                let fields_str = fields.join(",\n\t ",);
+                let bind_idx_str = bind_idx.join(", ",);
                 format!(
                     "INSERT INTO {}\n\t(\n\t {}\n\t)\n\tVALUES ({})\nRETURNING *;",
                     self.schema(),
@@ -276,29 +318,32 @@ pub trait ToSql<I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch> {
                     bind_idx_str,
                 )
             }
-            SqlStatement::InsertMany(_) => {
+            SqlStatement::InsertMany(_,) => {
                 unimplemented!();
             }
             // SqlStatement::Update: full-row update — every column in UpdateRow is written.
             // Uses a VALUES CTE (_z_) to bind all fields as positional params safely.
             // The WHERE clause targets the original table alias (_x_) via sql_where.
-            SqlStatement::Update(row) => {
-                let where_str =
-                    sql_where(self.filters(), self.statement().bind_len() + 1, Some("_x_".into()));
-                let (mut fields, bind_idx_option) = row.to_sql_parts();
+            SqlStatement::Update(row,) => {
+                let where_str = sql_where(
+                    self.filters(),
+                    self.statement().bind_len() + 1,
+                    Some("_x_".into(),),
+                );
+                let (mut fields, bind_idx_option,) = row.to_sql_parts();
                 let mut bind_idx =
-                    bind_idx_option.ok_or_else(|| anyhow!("cannot find binding index"))?;
+                    bind_idx_option.ok_or_else(|| anyhow!("cannot find binding index"),)?;
                 // Append `updated_by` automatically — sourced from session user.
-                fields.push("updated_by".into());
+                fields.push("updated_by".into(),);
                 let last_idx = bind_idx.len();
-                bind_idx.push(format!("${}", last_idx + 1));
-                let f = fields.join(",\n\t\t ");
+                bind_idx.push(format!("${}", last_idx + 1),);
+                let f = fields.join(",\n\t\t ",);
                 let f_f = fields
                     .into_iter()
-                    .map(|f| format!("\n\t\t{f} = _z_.{f}"))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                let v = bind_idx.join(", ");
+                    .map(|f| format!("\n\t\t{f} = _z_.{f}"),)
+                    .collect::<Vec<_,>>()
+                    .join(", ",);
+                let v = bind_idx.join(", ",);
                 let schema = self.schema();
                 format!(
                     "UPDATE {schema} _x_\n\tSET {f_f}\n\tFROM\n\t\t(VALUES ({v}))\n\tAS _z_ (\n\t\t {f}\n\t\t){where_str}\nRETURNING *;"
@@ -309,44 +354,48 @@ pub trait ToSql<I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch> {
             // SqlStatement::Update: callers specify exactly which columns change rather than
             // providing every column. Use patch() when you want to update 1–N fields without
             // overwriting the rest of the row.
-            SqlStatement::Patch(fields) => {
-                let where_str =
-                    sql_where(self.filters(), self.statement().bind_len() + 1, Some("_x_".into()));
-                let (mut fields, _) =
-                    concat_sql_parts(fields.iter().map(|f| f.to_sql_parts()).collect::<Vec<_>>());
+            SqlStatement::Patch(fields,) => {
+                let where_str = sql_where(
+                    self.filters(),
+                    self.statement().bind_len() + 1,
+                    Some("_x_".into(),),
+                );
+                let (mut fields, _,) = concat_sql_parts(
+                    fields.iter().map(|f| f.to_sql_parts(),).collect::<Vec<_,>>(),
+                );
                 let mut bind_idx =
-                    (0..fields.len()).map(|i| format!("${:?}", i + 1)).collect::<Vec<_>>();
+                    (0..fields.len()).map(|i| format!("${:?}", i + 1),).collect::<Vec<_,>>();
                 // Append `updated_by` — always sourced from session user, not from PatchField.
-                fields.push("updated_by".into());
+                fields.push("updated_by".into(),);
                 let last_idx = bind_idx.len();
-                bind_idx.push(format!("${}", last_idx + 1));
-                let f = fields.join(",\n\t\t ");
+                bind_idx.push(format!("${}", last_idx + 1),);
+                let f = fields.join(",\n\t\t ",);
                 let f_f = fields
                     .into_iter()
-                    .map(|f| format!("\n\t\t{f} = _z_.{f}"))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                let v = bind_idx.join(", ");
+                    .map(|f| format!("\n\t\t{f} = _z_.{f}"),)
+                    .collect::<Vec<_,>>()
+                    .join(", ",);
+                let v = bind_idx.join(", ",);
                 let schema = self.schema();
                 format!(
                     "UPDATE {schema} _x_\n\tSET {f_f}\n\tFROM\n\t\t(VALUES ({v}))\n\tAS _z_ (\n\t\t {f}\n\t\t){where_str}\nRETURNING *;"
                 )
             }
-        })
+        },)
     }
-    fn args(&self, session_user: &i32) -> sqlx::postgres::PgArguments {
+    fn args(&self, session_user: &i32,) -> sqlx::postgres::PgArguments {
         let mut args = sqlx::postgres::PgArguments::default();
         match self.statement() {
-            SqlStatement::Select(_) => {}
+            SqlStatement::Select(_,) => {}
             _ => {
-                self.statement().bind(&mut args);
+                self.statement().bind(&mut args,);
                 // Always bind session_user last for INSERT (created_by) and UPDATE/PATCH
                 // (updated_by). The placeholder is the final positional param in to_sql().
-                let _ = args.add(session_user);
+                let _ = args.add(session_user,);
             }
         };
         for w in self.filters().iter() {
-            w.bind(&mut args);
+            w.bind(&mut args,);
         }
         args
     }
@@ -357,29 +406,29 @@ pub trait ToSql<I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch> {
 /// Implemented automatically for any [`Builder`] that also implements [`ToSql`].
 /// The `fetch_all` method is the primary entry point for most callers; `execute` is
 /// for fire-and-forget mutations that don't need returned rows.
-pub trait Execute<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch>:
-    ToSql<I, U, F, P> + ContextAccessor
+pub trait Execute<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,>:
+    ToSql<I, U, F, P,> + ContextAccessor
 {
     /// Execute the statement without returning rows (e.g. a side-effect-only mutation).
-    fn execute(&self, _ctx: &C) -> impl std::future::Future<Output = anyhow::Result<()>> + Send
+    fn execute(&self, _ctx: &C,) -> impl std::future::Future<Output = anyhow::Result<(),>,> + Send
     where
-        Self: Sync
+        Self: Sync,
     {
         async { todo!() }
     }
     fn fetch_optional(
         &self,
-        _ctx: &C
-    ) -> impl std::future::Future<Output = anyhow::Result<Option<A>>> + Send
+        _ctx: &C,
+    ) -> impl std::future::Future<Output = anyhow::Result<Option<A,>,>,> + Send
     where
-        Self: Sync
+        Self: Sync,
     {
         async { todo!() }
     }
     /// Execute and return exactly one row, erroring if zero or more than one row is returned.
-    fn fetch_one(&self, _ctx: &C) -> impl std::future::Future<Output = anyhow::Result<A>> + Send
+    fn fetch_one(&self, _ctx: &C,) -> impl std::future::Future<Output = anyhow::Result<A,>,> + Send
     where
-        Self: Sync
+        Self: Sync,
     {
         async { todo!() }
     }
@@ -390,24 +439,24 @@ pub trait Execute<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToF
     ///
     /// Pass a `&mut Transaction` to participate in the caller's transaction, or the pool
     /// directly for auto-commit behaviour.
-    fn fetch_all<'c>(
+    fn fetch_all<'c,>(
         &self,
-        exec: impl Executor<'c, Database = Postgres>
-    ) -> impl std::future::Future<Output = anyhow::Result<Vec<A>>> + Send
+        exec: impl Executor<'c, Database = Postgres,>,
+    ) -> impl std::future::Future<Output = anyhow::Result<Vec<A,>,>,> + Send
     where
-        Self: Sync + Send
+        Self: Sync + Send,
     {
         async move {
             self.authenticate_request()?;
             let sql = self.to_sql()?;
-            let req = sqlx::query_as_with::<'_, sqlx::Postgres, A, sqlx::postgres::PgArguments>(
+            let req = sqlx::query_as_with::<'_, sqlx::Postgres, A, sqlx::postgres::PgArguments,>(
                 &sql,
-                self.args(self.session_user())
+                self.args(self.session_user(),),
             );
-            let res: anyhow::Result<Vec<A>> = req
-                .fetch_all(exec)
+            let res: anyhow::Result<Vec<A,>,> = req
+                .fetch_all(exec,)
                 .await
-                .map_err(|e| anyhow::anyhow!("Unable to fetch all: {}", e));
+                .map_err(|e| anyhow::anyhow!("Unable to fetch all: {}", e),);
             res
         }
     }
@@ -417,36 +466,36 @@ pub trait Execute<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToF
     ///   and at least one non-empty field (prevents no-op updates).
     /// - `Select`: requires exactly one field-block when using `fetch_all`; use
     ///   `fetch_all_raw` for multi-column projections.
-    fn authenticate_request(&self) -> Result<()> {
+    fn authenticate_request(&self,) -> Result<(),> {
         match self.statement() {
-            SqlStatement::Update(_) | SqlStatement::Patch(_) => {
+            SqlStatement::Update(_,) | SqlStatement::Patch(_,) => {
                 if self.filters().is_empty() {
-                    return Err(anyhow!("Unable to Update/Patch without filters"));
+                    return Err(anyhow!("Unable to Update/Patch without filters"),);
                 }
                 if self.statement().bind_len() < 1 {
-                    return Err(anyhow!("Unable to Update/Patch with all fields empty"));
+                    return Err(anyhow!("Unable to Update/Patch with all fields empty"),);
                 }
-                Ok(())
+                Ok((),)
             }
-            SqlStatement::Select(field_blocks) => {
+            SqlStatement::Select(field_blocks,) => {
                 if field_blocks.len() != 1 {
                     return Err(anyhow!(
                         "Unable to use the fetch_all method while choosing which fields to return. Use the fetch_all_raw() method."
-                    ));
+                    ),);
                 }
-                Ok(())
+                Ok((),)
             }
-            _ => Ok(())
+            _ => Ok((),),
         }
     }
 }
 
-impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch> Debug
-    for Builder<'_, C, A, I, U, F, P>
+impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch,> Debug
+    for Builder<'_, C, A, I, U, F, P,>
 where
-    Self: ToSql<I, U, F, P>
+    Self: ToSql<I, U, F, P,>,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_,>,) -> std::fmt::Result {
         write!(f, "\n{}\n\tSQL\n{}\n\n", "*".repeat(18), "*".repeat(18),)?;
         write!(f, "{}", self.to_sql().map_err(|_| std::fmt::Error)?)?;
         let mut bind_len = self.statement.bind_len();
@@ -456,10 +505,10 @@ where
             write!(f, "\n\n{}\n{}BINDINGS\n{}\n", "*".repeat(18), " ".repeat(5), "*".repeat(18),)?;
         }
         if !bind_len.is_zero() {
-            self.statement.fmt(f)?;
+            self.statement.fmt(f,)?;
         }
         match self.statement {
-            SqlStatement::Select(_) => writeln!(f),
+            SqlStatement::Select(_,) => writeln!(f),
             _ => {
                 bind_len += 1;
                 return write!(f, "\n\t${} = [session_user]\n", bind_len);
@@ -467,11 +516,11 @@ where
         }?;
 
         let mut filter_has_bindings = false;
-        let mut filter_bindings_string = String::from("");
+        let mut filter_bindings_string = String::from("",);
 
-        for (i, filter) in self.filters.iter().enumerate() {
+        for (i, filter,) in self.filters.iter().enumerate() {
             match filter {
-                FilterOp::And(_c, v) | FilterOp::Or(_c, v) | FilterOp::Begin(_c, v) => match v {
+                FilterOp::And(_c, v,) | FilterOp::Or(_c, v,) | FilterOp::Begin(_c, v,) => match v {
                     Filter::IsNull => {}
                     _ => {
                         _has_bindings = true;
@@ -480,9 +529,9 @@ where
                             "\n\t${} = {:?}",
                             i + bind_len + 1,
                             &filter
-                        ));
+                        ),);
                     }
-                }
+                },
             }
         }
         if filter_has_bindings {
@@ -505,6 +554,149 @@ where
 
         write!(f, "\n{}", "*".repeat(18))?;
         write!(f, "\n{}\n", "*".repeat(18))?;
-        std::fmt::Result::Ok(())
+        std::fmt::Result::Ok((),)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repo::map_util::{AsSqlParts, BindArgs, Filter, FilterOp, SqlStatement};
+    use std::fmt;
+
+    // ── Minimal stubs ────────────────────────────────────────────────────────
+
+    /// A stub column that satisfies `ToField` (`ToSqlParts + Display`).
+    #[derive(Debug, Clone,)]
+    struct Col(&'static str,);
+
+    impl fmt::Display for Col {
+        fn fmt(&self, f: &mut fmt::Formatter<'_,>,) -> fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
+    impl crate::repo::map_util::ToSqlParts for Col {
+        fn to_sql_parts(&self,) -> AsSqlParts {
+            // SELECT branch pops the last element as the binding index placeholder;
+            // we push a dummy so the pop succeeds and the real name is kept.
+            (vec![self.0.to_string(), String::new()], None,)
+        }
+    }
+
+    impl BindArgs for Col {
+        fn bind(&self, _args: &mut sqlx::postgres::PgArguments,) {}
+        fn bind_len(&self,) -> usize {
+            0
+        }
+    }
+
+    // ── Struct that lets us exercise `ToSql::to_sql` directly ────────────────
+
+    struct MockQuery {
+        statement: SqlStatement<Col, Col, Col, Col,>,
+        filters: Vec<FilterOp<Col,>,>,
+        schema: String,
+        limit: Option<i64,>,
+        offset: Option<i64,>,
+    }
+
+    impl MockQuery {
+        fn select(schema: &str, cols: Vec<Col,>,) -> Self {
+            Self {
+                statement: SqlStatement::Select(cols,),
+                filters: vec![],
+                schema: schema.to_string(),
+                limit: None,
+                offset: None,
+            }
+        }
+    }
+
+    impl ToSql<Col, Col, Col, Col,> for MockQuery {
+        fn statement(&self,) -> &SqlStatement<Col, Col, Col, Col,> {
+            &self.statement
+        }
+        fn filters(&self,) -> &Vec<FilterOp<Col,>,> {
+            &self.filters
+        }
+        fn schema(&self,) -> &String {
+            &self.schema
+        }
+        fn limit(&self,) -> Option<i64,> {
+            self.limit
+        }
+        fn offset(&self,) -> Option<i64,> {
+            self.offset
+        }
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    /// A plain SELECT should contain neither LIMIT nor OFFSET.
+    #[test]
+    fn select_no_limit_no_offset() {
+        let q = MockQuery::select("public.users", vec![Col("id",)],);
+        let sql = q.to_sql().expect("to_sql failed",);
+        assert!(!sql.contains("LIMIT"), "unexpected LIMIT in: {sql}");
+        assert!(!sql.contains("OFFSET"), "unexpected OFFSET in: {sql}");
+    }
+
+    /// `limit` alone should append `LIMIT n` after WHERE (or table name if no WHERE).
+    #[test]
+    fn select_limit_only() {
+        let mut q = MockQuery::select("public.orders", vec![Col("id",)],);
+        q.limit = Some(10,);
+        let sql = q.to_sql().expect("to_sql failed",);
+        assert!(sql.contains("LIMIT 10"), "expected LIMIT 10 in:\n{sql}");
+        assert!(!sql.contains("OFFSET"), "unexpected OFFSET in:\n{sql}");
+    }
+
+    /// `offset` alone should append `OFFSET n` (without a preceding LIMIT).
+    #[test]
+    fn select_offset_only() {
+        let mut q = MockQuery::select("public.orders", vec![Col("id",)],);
+        q.offset = Some(20,);
+        let sql = q.to_sql().expect("to_sql failed",);
+        assert!(sql.contains("OFFSET 20"), "expected OFFSET 20 in:\n{sql}");
+        assert!(!sql.contains("LIMIT"), "unexpected LIMIT in:\n{sql}");
+    }
+
+    /// Both limit and offset should produce `LIMIT n OFFSET m` in that order.
+    #[test]
+    fn select_limit_and_offset() {
+        let mut q = MockQuery::select("public.items", vec![Col("name",)],);
+        q.limit = Some(5,);
+        q.offset = Some(15,);
+        let sql = q.to_sql().expect("to_sql failed",);
+        assert!(
+            sql.contains("LIMIT 5 OFFSET 15"),
+            "expected 'LIMIT 5 OFFSET 15' in:\n{sql}"
+        );
+    }
+
+    /// `LIMIT/OFFSET` must appear after the WHERE clause, not before it.
+    #[test]
+    fn limit_offset_after_where_clause() {
+        let mut q = MockQuery::select("public.events", vec![Col("id",)],);
+        q.filters = vec![FilterOp::Begin(Col("active",), Filter::IsNull,)];
+        q.limit = Some(3,);
+        q.offset = Some(6,);
+        let sql = q.to_sql().expect("to_sql failed",);
+        let where_pos = sql.find("WHERE").expect("expected WHERE",);
+        let limit_pos = sql.find("LIMIT").expect("expected LIMIT",);
+        assert!(
+            limit_pos > where_pos,
+            "LIMIT must appear after WHERE — got:\n{sql}"
+        );
+    }
+
+    /// Default `ToSql` trait implementations return `None` for limit/offset.
+    #[test]
+    fn tosql_trait_defaults_return_none() {
+        let q = MockQuery::select("t", vec![Col("x",)],);
+        // We override both, so verify the overrides work correctly.
+        assert_eq!(q.limit(), None);
+        assert_eq!(q.offset(), None);
     }
 }


### PR DESCRIPTION
## Issue
Closes #22 (recovered from stale PR #49)

## Summary
Adds `offset(n)` and `limit(n)` builder methods to the select chain for pagination support.

## Context for Reviewer
Pagination support for the repo builder. Services need this for list endpoints. Consistent with existing builder pattern.