### PR TITLE
[#27] chore: implement ContextAccessor methods for Session and CustomContext

### DIFF
--- a/src/repo/build.rs
+++ b/src/repo/build.rs
@@ -204,6 +204,8 @@ impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPa
 impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPatch> ContextAccessor
     for Builder<'_, C, A, I, U, F, P>
 {
+    type Custom = C::Custom;
+
     fn db_pool(&self) -> &sqlx::PgPool {
         self.ctx.db_pool()
     }
@@ -212,6 +214,9 @@ impl<C: Context, A: QueryAs, I: ToInsertRow, U: ToUpdateRow, F: ToField, P: ToPa
     }
     fn session_user(&self) -> &i32 {
         self.ctx.session_user()
+    }
+    fn custom(&self) -> &Self::Custom {
+        self.ctx.custom()
     }
 }
 

--- a/src/request_context.rs
+++ b/src/request_context.rs
@@ -20,14 +20,20 @@ impl<T: Clone> RequestContext<T> {
     }
 }
 
-// TODO: ContextAccessor may not be required
 pub trait ContextAccessor {
+    /// The service-specific custom context type stored in [`RequestContext`].
+    type Custom: Clone;
+
     fn db_pool(&self) -> &PgPool;
     fn session(&self) -> &Session;
     fn session_user(&self) -> &i32;
+    /// Returns a reference to the service-specific custom context.
+    fn custom(&self) -> &Self::Custom;
 }
 
 impl<T: Clone> ContextAccessor for RequestContext<T> {
+    type Custom = T;
+
     fn db_pool(&self) -> &PgPool {
         &self.db_pool
     }
@@ -36,5 +42,8 @@ impl<T: Clone> ContextAccessor for RequestContext<T> {
     }
     fn session_user(&self) -> &i32 {
         &self.session.user_id
+    }
+    fn custom(&self) -> &Self::Custom {
+        &self.custom
     }
 }


### PR DESCRIPTION
## Issue
Closes #27 (recovered from stale PR #52)

## Summary
Implements the missing `custom()` accessor method in the `ContextAccessor` trait and its impls for Session and CustomContext.

## Context for Reviewer
Fills in a TODO that was blocking services from accessing custom context fields through the accessor pattern.