### PR TITLE
[#37] Export initial public test-utils surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,19 @@ For safety, fallback mode refuses database names that do not include `_test`.
 ## License
 
 MIT
+
+## `test-utils` quickstart
+
+```rust,no_run
+use mae::testing::{context::TestContext, must::Must};
+use mae_macros::mae_test;
+
+#[mae_test(docker, teardown = mae::testing::containers::teardown_all)]
+async fn integration_test_insert_vendor() {
+    let ctx = TestContext::<()>::new().await.must();
+
+    // run queries against ctx.pool, namespaced by ctx.schema as needed
+
+    ctx.teardown().await.must();
+}
+```

--- a/src/testing/context.rs
+++ b/src/testing/context.rs
@@ -1,72 +1,80 @@
 //! [`TestContext`] — a generic test context for Mae-based services.
 //!
 //! `TestContext<C>` wraps a service-specific custom context type `C` and
-//! provides access to the shared Postgres pool.  Services define their own `C`
-//! (e.g. mock clients, feature flags) and pass it through.
-//!
-//! ## Usage
-//! ```rust,no_run
-//! use mae::testing::context::{TestContext, get_context};
-//!
-//! #[derive(Default, Clone)]
-//! struct MyCtx { /* service-specific fields */ }
-//!
-//! #[tokio::test]
-//! async fn my_test() {
-//!     let ctx = get_context::<MyCtx>().await.unwrap();
-//!     // ctx.db_pool — shared pool
-//!     // ctx.custom.inner — your MyCtx
-//! }
-//! ```
+//! provides access to a shared Postgres pool plus per-test schema isolation.
 
 use anyhow::Result;
+use sqlx::{Executor, PgPool};
 use std::sync::Arc;
+use uuid::Uuid;
 
 use crate::request_context::RequestContext;
 use crate::session::Session;
 use crate::testing::container::postgres;
 
-// Re-export the free functions that lived here pre-refactor so existing
-// consumers don't need to update their imports.
-pub use postgres::{pg_singleton as pg_container, spawn_scoped_schema, teardown};
-
-// ── TestContext ───────────────────────────────────────────────────────────────
+/// Re-export the Postgres singleton helper.
+pub use postgres::pg_singleton as pg_container;
 
 /// Generic test context wrapping a service-specific type `C`.
-///
-/// `C` is the same type used as the type parameter of [`RequestContext`] in the
-/// service under test.  In tests you typically define a lightweight `struct
-/// TestCustom { … }` that implements [`Default`] and [`Clone`].
 #[derive(Clone)]
-pub struct TestContext<C> {
+pub struct TestContext<C = ()> {
     /// Service-specific context, accessible from within tests.
-    pub inner: C
+    pub inner: C,
+    /// Shared Postgres pool for this test run.
+    pub pool: PgPool,
+    /// Per-test schema name (`test_<uuid>`).
+    pub schema: String
 }
 
 impl<C: Default + Clone> TestContext<C> {
+    /// Build a new isolated [`TestContext`].
+    pub async fn new() -> Result<Self> {
+        let pool = postgres::shared_pool().await?.clone();
+        let schema = spawn_scoped_schema(&pool).await?;
+
+        Ok(Self { inner: C::default(), pool, schema })
+    }
+
+    /// Drop the scoped schema created for this test context.
+    pub async fn teardown(&self) -> Result<()> {
+        teardown(&self.pool, &self.schema).await
+    }
+
     /// Open a fresh [`sqlx::PgConnection`] with `search_path` set to a unique
     /// schema, providing strong per-test schema isolation.
     pub async fn scoped_connection(&self) -> Result<sqlx::PgConnection> {
-        let scope = spawn_scoped_schema().await?;
+        let scope = postgres::spawn_scoped_schema().await?;
         Ok(scope.conn)
     }
+}
+
+/// Create a unique schema (`test_<uuid>`) for one test.
+pub async fn spawn_scoped_schema(pool: &PgPool) -> Result<String> {
+    let schema = format!("test_{}", Uuid::new_v4().simple());
+    pool.execute(format!(r#"CREATE SCHEMA IF NOT EXISTS \"{schema}\""#).as_str()).await?;
+    Ok(schema)
+}
+
+/// Drop a previously-created scoped schema.
+pub async fn teardown(pool: &PgPool, schema: &str) -> Result<()> {
+    pool.execute(format!(r#"DROP SCHEMA IF EXISTS \"{schema}\" CASCADE"#).as_str()).await?;
+    Ok(())
 }
 
 /// Convenience type alias matching the downstream service pattern.
 pub type Ctx<C> = RequestContext<TestContext<C>>;
 
-// ── Context builder ───────────────────────────────────────────────────────────
-
 /// Build a [`Ctx<C>`] backed by the shared Postgres pool.
-///
-/// `C` must implement [`Default`] (used to construct [`TestContext::inner`]).
 pub async fn get_context<C: Default + Clone>() -> Result<RequestContext<TestContext<C>>> {
-    let pool = postgres::shared_pool().await?;
-    let pool = Arc::new(pool.clone());
+    let base_pool = postgres::shared_pool().await?.clone();
+    let schema = spawn_scoped_schema(&base_pool).await?;
+
+    // Keep RequestContext's db_pool as an Arc clone of the shared pool.
+    let pool = Arc::new(base_pool.clone());
 
     Ok(RequestContext::<TestContext<C>> {
         db_pool: pool,
         session: Session { user_id: 1 },
-        custom: TestContext { inner: C::default() }.into()
+        custom: TestContext { inner: C::default(), pool: base_pool, schema }.into()
     })
 }

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -10,13 +10,18 @@
 //! # Modules
 //! | Module | Purpose |
 //! |---|---|
-//! | [`container`] | Docker container singletons (Postgres ✅, Redis/Neo4j/RabbitMQ ✅ #40) |
-//! | [`context`]   | [`TestContext<C>`](context::TestContext) — generic test request context |
+//! | [`container`] / [`containers`] | Docker container singletons (Postgres, Redis, Neo4j, RabbitMQ) |
+//! | [`context`]   | [`TestContext<C>`](context::TestContext) + scoped schema helpers |
 //! | [`env`]       | `.env` loader for test credentials |
 //! | [`must`]      | Assertion helpers (`MustExpect`, `must_eq`, …) |
 
 #[cfg(feature = "test-utils")]
 pub mod container;
+
+#[cfg(feature = "test-utils")]
+pub mod containers {
+    pub use super::container::*;
+}
 
 #[cfg(feature = "test-utils")]
 pub mod context;


### PR DESCRIPTION
## Summary
Implements the first exportable `test-utils` surface for downstream services.

### What changed
- Added `mae::testing::containers` compatibility module re-exporting the existing `container` API.
- Expanded `mae::testing::context::TestContext` to expose:
  - `pool: PgPool`
  - `schema: String`
  - `new()` constructor for isolated test setup
  - `teardown()` for schema cleanup
- Added public schema helpers in `mae::testing::context`:
  - `spawn_scoped_schema(pool)`
  - `teardown(pool, schema)`
- Updated README with minimal usage example including `#[mae_test]` + teardown hook.

Closes #37

## Gate checks run
- ✅ cargo +nightly fmt -- --check
- ✅ cargo +nightly clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks
- ✅ cargo +nightly miri test --lib -- --nocapture
- ✅ cargo +nightly deny check
- ❌ cargo +nightly llvm-cov --lib --fail-under-lines 50 (current lib test suite executes 0 tests, measured 0.00% total)