### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mae"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 license = "MIT"
 description = "Opinionated async Rust framework for building Mae-Technologies micro-services — app scaffolding, repo layer, middleware, and test utilities."


### PR DESCRIPTION
Bump crate version for crates.io publish with new IntoMaeFilter impls (bool, NaiveDate, Decimal, Uuid).