### PR TITLE
feat: add Staging environment variant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mae"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "MIT"
 description = "Opinionated async Rust framework for building Mae-Technologies micro-services — app scaffolding, repo layer, middleware, and test utilities."

--- a/src/app/configuration.rs
+++ b/src/app/configuration.rs
@@ -205,6 +205,7 @@ pub struct ApplicationSettings {
 pub enum Environment {
     Local,
     Production,
+    Staging,
     Test
 }
 
@@ -213,6 +214,7 @@ impl Environment {
         match self {
             Environment::Local => "local",
             Environment::Production => "production",
+            Environment::Staging => "staging",
             Environment::Test => "test"
         }
     }
@@ -225,6 +227,7 @@ impl TryFrom<String> for Environment {
         match s.to_lowercase().as_str() {
             "local" => Ok(Self::Local),
             "production" => Ok(Self::Production),
+            "staging" => Ok(Self::Staging),
             "test" => Ok(Self::Test),
             other => Err(anyhow!("{} is not a supported environment", other))
         }


### PR DESCRIPTION
`mae::Environment` only supported `Local`, `Production`, `Test`.

Add `Staging` so services can set `APP_ENVIRONMENT=staging` and load `configuration/staging.yaml` for staging-specific overrides.

Bumps crate to 0.3.2.