### PR TITLE
feat: add built-in /health, /health-pg, /health-neo endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ test-utils = [
 panic = "unwind"
 
 [dependencies]
-mae_macros = "0.1.1"
+mae_macros = { git = "https://github.com/Mae-Technologies/mae_macros.git", branch = "sandbox" }
 neo4rs = "0.8"
 chrono = { version = "0.4.43", features = ["serde"] }
 serde_json = "1.0.149"

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,0 +1,33 @@
+//! Built-in health check handlers for mae applications.
+//!
+//! These are automatically registered by the `#[run_app]` macro — no
+//! service-level code needed.
+
+use actix_web::{get, web, HttpResponse};
+use sqlx::PgPool;
+
+/// Basic liveness probe — always returns 200.
+#[get("/health")]
+pub async fn health() -> HttpResponse {
+    HttpResponse::Ok().json(serde_json::json!({"status": "ok"}))
+}
+
+/// Postgres readiness probe — checks DB connectivity.
+#[get("/health-pg")]
+pub async fn health_pg(pool: web::Data<PgPool>) -> HttpResponse {
+    match sqlx::query("SELECT 1").execute(pool.get_ref()).await {
+        Ok(_) => HttpResponse::Ok().json(serde_json::json!({"status": "ok", "db": "postgres"})),
+        Err(_) => HttpResponse::ServiceUnavailable()
+            .json(serde_json::json!({"status": "error", "db": "postgres"})),
+    }
+}
+
+/// Neo4j readiness probe — checks graph DB connectivity.
+#[get("/health-neo")]
+pub async fn health_neo(graph: web::Data<neo4rs::Graph>) -> HttpResponse {
+    match graph.run(neo4rs::query("RETURN 1 AS _n")).await {
+        Ok(_) => HttpResponse::Ok().json(serde_json::json!({"status": "ok", "db": "neo4j"})),
+        Err(_) => HttpResponse::ServiceUnavailable()
+            .json(serde_json::json!({"status": "error", "db": "neo4j"})),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
 pub mod app;
+pub mod health;
 pub mod error_response;
 pub mod middleware;
 pub mod repo;


### PR DESCRIPTION
## Summary
Add built-in /health, /health-pg, and /health-neo endpoints to the mae library so services get consistent health checks for free, auto-injected by the #[run_app] macro.

## Changes
- Add mae::health module exposing handlers for /health, /health-pg, and /health-neo
- Wire mae::health into the public module tree
- Point mae_macros dependency at the sandbox branch so #[run_app] can auto-register the new endpoints

Closes #90

## Test Results
- cargo +nightly fmt -- --check ✅
- cargo +nightly clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks ✅ (no errors)
- cargo +nightly miri test --lib ⏭️ (not run; not required per task instructions)
- cargo +nightly test --features integration-tests ⏭️ (not run; not required per task instructions)
- cargo +nightly deny check ❌ (cargo-deny subcommand not installed in this environment)
- cargo +nightly llvm-cov --lib --summary-only ✅ (summary-only run; see CI for detailed coverage)
