### PR TITLE
fix(testing): extend neo4j testcontainer startup timeout to 120s (0.3.5)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mae"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 license = "MIT"
 description = "Opinionated async Rust framework for building Mae-Technologies micro-services — app scaffolding, repo layer, middleware, and test utilities."

--- a/src/testing/container/neo4j.rs
+++ b/src/testing/container/neo4j.rs
@@ -15,9 +15,10 @@
 //! to delete all nodes carrying the prefix label.
 
 use std::sync::OnceLock;
+use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
-use testcontainers::{ContainerAsync, runners::AsyncRunner};
+use testcontainers::{ContainerAsync, core::ImageExt as _, runners::AsyncRunner};
 use testcontainers_modules::neo4j::{Neo4j, Neo4jImage};
 use tokio::sync::Mutex;
 use uuid::Uuid;
@@ -155,8 +156,12 @@ async fn ensure_started() -> Result<()> {
 
     let mut guard = neo4j_mutex().lock().await;
     if guard.is_none() {
+        // Neo4j 5 can take 60–90 s to become ready on slower machines.
+        // The testcontainers default startup timeout is 60 s, which is frequently
+        // too short.  We use 120 s to give adequate headroom.
         let container: ContainerAsync<Neo4jImage> = Neo4j::new()
             .with_password("testpassword")
+            .with_startup_timeout(Duration::from_secs(120))
             .start()
             .await
             .context("failed to start Neo4j container")?;


### PR DESCRIPTION
## Problem

`get_neo4j_bolt()` starts the Neo4j container via testcontainers with no explicit startup timeout, falling back to the library default of **60 seconds**. Neo4j 5 regularly takes 60–90 s to become ready on typical CI runners and developer machines, causing intermittent `failed to start Neo4j container` failures.

## Change

- `src/testing/container/neo4j.rs` — add `.with_startup_timeout(Duration::from_secs(120))` to the container start call in `ensure_started()`
- Version bump: `0.3.4` → `0.3.5`

## Context

Surfaced in `ru_widget_service` PR#106 (`health_check_returns_200` failing with 108 s timeout). A workaround was initially added to the service's `tests/api/helpers.rs` but moved here per review feedback — the fix belongs in mae.