### PR TITLE
fix(concourse): clippy, unit tests, and doctest failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,13 @@ dotenvy = "0.15.7"
 url = "2.5.8"
 shellexpand = "3.1.1"
 
+# coverage_tests imports mae::testing::must (test-utils). Without this gate,
+# `cargo test` (Concourse mae-unit) tries to build the binary without test-utils.
+[[test]]
+name = "coverage_tests"
+path = "tests/coverage_tests.rs"
+required-features = ["test-utils"]
+
 [lints.clippy]
 unwrap_used = "deny"
 expect_used = "deny"

--- a/src/route/response.rs
+++ b/src/route/response.rs
@@ -96,7 +96,7 @@ impl actix_web::ResponseError for ServiceError {
 /// # Examples
 ///
 /// ```
-/// use mae::error_response::e500;
+/// use mae::route::response::e500;
 ///
 /// let err = e500("something went wrong");
 /// assert_eq!(err.as_response_error().status_code(), actix_web::http::StatusCode::INTERNAL_SERVER_ERROR);
@@ -113,7 +113,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use mae::error_response::e401;
+/// use mae::route::response::e401;
 ///
 /// let err = e401("unauthorized");
 /// assert_eq!(err.as_response_error().status_code(), actix_web::http::StatusCode::UNAUTHORIZED);
@@ -130,7 +130,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use mae::error_response::e400;
+/// use mae::route::response::e400;
 ///
 /// let err = e400("invalid input");
 /// assert_eq!(err.as_response_error().status_code(), actix_web::http::StatusCode::BAD_REQUEST);

--- a/src/session.rs
+++ b/src/session.rs
@@ -23,9 +23,9 @@ use crate::route::response::ServiceError;
 /// ```
 /// use mae::session::Session;
 ///
-/// let session = Session { user_id: 42 };
-/// assert_eq!(*session, 42);           // Deref to i32
-/// assert_eq!(format!("{}", session), "42"); // Display
+/// let session = Session(Some(42));
+/// assert_eq!(*session, Some(42));
+/// assert_eq!(format!("{}", session), "42");
 /// ```
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Session(pub Option<i32>);

--- a/src/testing/context.rs
+++ b/src/testing/context.rs
@@ -41,14 +41,14 @@ impl<C: Default + Clone> TestContext<C> {
 pub type Ctx<C> = RequestContext<TestContext<C>>;
 
 /// Build a [`Ctx<C>`] backed by the shared Postgres pool.
-pub async fn get_context<'a, C: Default + Clone>() -> Result<RequestContext<TestContext<C>>> {
+pub async fn get_context<C: Default + Clone>() -> Result<RequestContext<TestContext<C>>> {
     let base_pool = postgres::shared_pool().await?.clone();
     let pool = Arc::new(base_pool.clone());
     let session = Arc::new(Session(Some(1)));
     let ctx = RequestContext::<TestContext<C>>::new(
         pool,
         session,
-        Arc::new(TestContext { inner: C::default(), pool: base_pool }.into())
+        Arc::new(TestContext { inner: C::default(), pool: base_pool })
     )
     .await?;
 

--- a/tests/common/context.rs
+++ b/tests/common/context.rs
@@ -6,7 +6,7 @@ pub struct TestContext {}
 
 pub type Ctx = RequestContext<mae::testing::context::TestContext<TestContext>>;
 
-pub async fn get_context<'c>() -> Result<Ctx> {
+pub async fn get_context() -> Result<Ctx> {
     mae::testing::context::get_context::<TestContext>().await
 }
 

--- a/tests/coverage/telemetry_unit.rs
+++ b/tests/coverage/telemetry_unit.rs
@@ -4,7 +4,7 @@ use mae::testing::must::must_eq;
 #[test]
 fn get_subscriber_builds_without_panicking() {
     let _subscriber =
-        get_subscriber("mae-coverage".to_string(), "info".to_string(), || std::io::sink());
+        get_subscriber("mae-coverage".to_string(), "info".to_string(), std::io::sink);
 }
 
 #[tokio::test]

--- a/tests/coverage/telemetry_unit.rs
+++ b/tests/coverage/telemetry_unit.rs
@@ -3,8 +3,7 @@ use mae::testing::must::must_eq;
 
 #[test]
 fn get_subscriber_builds_without_panicking() {
-    let _subscriber =
-        get_subscriber("mae-coverage".to_string(), "info".to_string(), std::io::sink);
+    let _subscriber = get_subscriber("mae-coverage".to_string(), "info".to_string(), std::io::sink);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Concourse failures addressed (build #3, 2026-07-05)

### mae-integrity (clippy)
- `src/testing/context.rs`: remove unused `'a` lifetime and useless `.into()` (`extra_unused_lifetimes`, `useless_conversion`)
- `tests/common/context.rs`: remove unused lifetime on test helper
- `tests/coverage/telemetry_unit.rs`: fix redundant closure

Concourse runs `clippy --all-targets --all-features -D warnings -D clippy::undocumented_unsafe_blocks`.

### mae-unit (`cargo test`)
- Gate `coverage_tests` behind `required-features = ["test-utils"]` so plain `cargo test` (no features) no longer compiles the coverage binary without `mae::testing::must`
- Fix stale doctests: `mae::error_response::*` → `mae::route::response::*`; `Session(Some(42))` example

### mae-integration — not fixed here
Build #3 failed because **postgres-mae `entry_point.sh` did not become ready** (DB wipe/reset loop in test mode). That is the Concourse postgres-mae image sidecar, not mae crate code. Needs follow-up on `postgres-mae` image tag / `concourse_ci` task env once the image is stable on the `lib` team pipeline.

## Verify locally
```bash
cargo +nightly clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks
cargo +nightly test
cargo deny check
```