### PR TITLE
fix(service): graceful empty downstream error bodies (0.3.12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2207,7 +2207,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mae"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "actix-cors",
  "actix-session",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mae"
-version = "0.3.11"
+version = "0.3.12"
 edition = "2024"
 license = "MIT"
 description = "Opinionated async Rust framework for building Mae-Technologies micro-services — app scaffolding, repo layer, middleware, and test utilities."

--- a/src/service.rs
+++ b/src/service.rs
@@ -5,7 +5,6 @@
 //! `data` field and maps HTTP status codes back into [`Success`] / [`ServiceError`].
 
 use crate::route::response::{ServiceError, ServiceResult, Success};
-use anyhow::Context;
 use reqwest::{Client, header};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -93,6 +92,23 @@ where
         .map_err(|e| ServiceError::Unexpected(anyhow::anyhow!("deserialize failed: {e}")))
 }
 
+fn parse_response_body(status: reqwest::StatusCode, body: &str) -> Result<Value, ServiceError> {
+    if body.trim().is_empty() {
+        if status.is_success() {
+            return Err(ServiceError::Unexpected(anyhow::anyhow!("parse failed: empty body")));
+        }
+        return Ok(Value::Null);
+    }
+
+    match serde_json::from_str::<Value>(body) {
+        Ok(value) => Ok(value),
+        Err(error) if status.is_success() => {
+            Err(ServiceError::Unexpected(anyhow::anyhow!("parse failed: {error}")))
+        }
+        Err(_) => Ok(Value::Null)
+    }
+}
+
 impl HttpServiceClient {
     pub fn new(config: ServiceClientConfig) -> Self {
         Self {
@@ -135,7 +151,10 @@ impl HttpServiceClient {
         R: DeserializeOwned + Serialize
     {
         let status = response.status();
-        let value = response.json::<Value>().await.context("parse failed")?;
+        let body = response.text().await.map_err(|error| {
+            ServiceError::Unexpected(anyhow::anyhow!("read body failed: {error}"))
+        })?;
+        let value = parse_response_body(status, &body)?;
 
         if status.is_success() {
             map_http_status_to_success(status, deserialize_response(value)?)
@@ -264,6 +283,28 @@ mod tests {
             serde_json::json!({"error": "trial"})
         );
         assert!(matches!(err, ServiceError::UnprocessableEntity(_)));
+    }
+
+    #[test]
+    fn parse_response_body_maps_empty_error_body_to_null() {
+        let value = parse_response_body(ReqStatus::NOT_FOUND, "").expect("null body");
+        assert!(value.is_null());
+
+        let err = parse_response_body(ReqStatus::OK, "").expect_err("empty success body");
+        assert!(matches!(err, ServiceError::Unexpected(_)));
+    }
+
+    #[test]
+    fn parse_response_body_maps_empty_404_to_not_found() {
+        let value = parse_response_body(ReqStatus::NOT_FOUND, "").expect("null body");
+        let err = map_http_status_to_error(ReqStatus::NOT_FOUND, value);
+        assert!(matches!(err, ServiceError::NotFound(_)));
+    }
+
+    #[test]
+    fn parse_response_body_maps_invalid_error_body_to_null() {
+        let value = parse_response_body(ReqStatus::NOT_FOUND, "not json").expect("null body");
+        assert!(value.is_null());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes staging UI 500s caused by `HttpServiceClient` failing to parse empty Actix 404 bodies when proxying merchant service calls.

## Problem

`ru-api-service` proxies merchant endpoints (e.g. `GET /merchant/partner-config`). When merchant returns **404 with an empty body**, `handle_response` called `response.json()` before checking status → JSON EOF → `ServiceError::Unexpected` → **HTTP 500** to the frontend.

## Fix

- Read response body as text, parse via new `parse_response_body` helper
- Empty or non-JSON bodies on **error** statuses fall back to `Value::Null`
- `map_http_status_to_error` then returns the correct 4xx (e.g. `NotFound` for 404)
- Success responses with empty/invalid JSON still surface as 500 (downstream contract unchanged)

## Version

Bumps `mae` **0.3.11 → 0.3.12** for crates.io publish via Concourse `publish-mae`.

## Tests

- `parse_response_body_maps_empty_error_body_to_null`
- `parse_response_body_maps_empty_404_to_not_found`
- `parse_response_body_maps_invalid_error_body_to_null`

All pre-push gates passed (nextest, llvm-cov ≥65%, clippy, cargo deny).

## Follow-up (separate PRs)

- Tap `mae = "0.3.12"` in all `ru_*` services
- Merge `model-migration` into `ru_merchant_service` to restore missing routes