### PR TITLE
feat: PostingController for queue dequeue sagas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,9 +697,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -981,18 +981,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -2082,11 +2082,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -2289,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mime"
@@ -2432,11 +2432,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -3110,9 +3109,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3122,9 +3121,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3393,9 +3392,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -5096,18 +5095,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //! - [`app`] — configuration, `DeriveContext`, Actix server `run`
 //! - [`context`] — [`RequestContext`] (pool + session + custom config per request)
 //! - [`repo`] — typed Postgres layer: [`WithExecutor`](repo::WithExecutor), filters, [`DomainStatus`](repo::default::DomainStatus)
+//! - [`posting`] — multi-step post orchestration ([`PostingController`](posting::PostingController))
 //! - [`route`] — [`Success`](route::response::Success), [`ServiceError`](route::response::ServiceError), health routes
 //! - [`middleware`] — session / micro-service auth (installed by `#[run_app]`)
 //! - [`session`] — logged-in user identity
@@ -28,6 +29,7 @@ pub mod app;
 pub mod context;
 pub mod crypto;
 pub mod middleware;
+pub mod posting;
 pub mod repo;
 pub mod route;
 pub mod service;

--- a/src/posting/controller.rs
+++ b/src/posting/controller.rs
@@ -1,0 +1,240 @@
+use super::step::{BoxPostingStep, PostingStep, StepOutcome};
+
+/// Shared mutable state passed through every step.
+///
+/// Prefer a concrete service type for `T` (journal ids, op ids, intake refs) —
+/// not a free-form JSON bag.
+#[derive(Debug)]
+pub struct PostingContext<T> {
+    pub write_details: T,
+    pub errors: Vec<String>
+}
+
+impl<T> PostingContext<T> {
+    pub fn new(write_details: T) -> Self {
+        Self { write_details, errors: Vec::new() }
+    }
+
+    pub fn push_error(&mut self, message: impl Into<String>) {
+        self.errors.push(message.into());
+    }
+}
+
+/// Result of [`PostingController::attempt`].
+#[derive(Debug, Clone)]
+pub struct PostingReport {
+    /// Overall success (all executes ok, or no steps).
+    pub success: bool,
+    /// `0` = no undo needed; `1` = undo completed; `-1` = undo failed for a step.
+    pub fail_success: i8,
+    /// Step names that completed successfully (before any failure).
+    pub completed_steps: Vec<String>,
+    /// Step that failed execute, if any.
+    pub failed_step: Option<String>,
+    /// Accumulated error messages (execute + undo).
+    pub errors: Vec<String>
+}
+
+/// Facade that runs steps in order and undoes completed ones on failure.
+pub struct PostingController<T> {
+    steps: Vec<BoxPostingStep<T>>
+}
+
+impl<T> PostingController<T> {
+    pub fn new() -> Self {
+        Self { steps: Vec::new() }
+    }
+
+    pub fn with_steps(steps: Vec<BoxPostingStep<T>>) -> Self {
+        Self { steps }
+    }
+
+    pub fn push_step(&mut self, step: impl PostingStep<T> + 'static) {
+        self.steps.push(Box::new(step));
+    }
+
+    /// Execute all steps. On first execute error, undo completed steps in reverse.
+    pub async fn attempt(mut self, ctx: &mut PostingContext<T>) -> PostingReport {
+        let mut completed: Vec<usize> = Vec::new();
+        let mut completed_names: Vec<String> = Vec::new();
+
+        for (idx, step) in self.steps.iter_mut().enumerate() {
+            let name = step.name().to_string();
+            match step.execute(ctx).await {
+                Ok(StepOutcome::Completed) | Ok(StepOutcome::Skipped) => {
+                    completed.push(idx);
+                    completed_names.push(name);
+                }
+                Err(err) => {
+                    ctx.push_error(format!("step `{name}` failed: {err}"));
+                    let fail_success = undo_completed(&mut self.steps, &completed, ctx).await;
+                    return PostingReport {
+                        success: false,
+                        fail_success,
+                        completed_steps: completed_names,
+                        failed_step: Some(name),
+                        errors: ctx.errors.clone()
+                    };
+                }
+            }
+        }
+
+        PostingReport {
+            success: true,
+            fail_success: 0,
+            completed_steps: completed_names,
+            failed_step: None,
+            errors: ctx.errors.clone()
+        }
+    }
+}
+
+impl<T> Default for PostingController<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Undo completed steps LIFO. Returns `1` if all undos ok, `-1` if any undo fails.
+async fn undo_completed<T>(
+    steps: &mut [BoxPostingStep<T>],
+    completed: &[usize],
+    ctx: &mut PostingContext<T>
+) -> i8 {
+    if completed.is_empty() {
+        return 0;
+    }
+
+    let mut fail_success: i8 = 1;
+    for &idx in completed.iter().rev() {
+        let name = steps[idx].name().to_string();
+        if let Err(err) = steps[idx].undo(ctx).await {
+            fail_success = -1;
+            ctx.push_error(format!("undo of step `{name}` failed: {err}"));
+        }
+    }
+    fail_success
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::posting::step::{BoxFuture, PostingError, PostingStep, StepOutcome};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Debug, Default)]
+    struct Details {
+        log: Vec<String>
+    }
+
+    struct MockStep {
+        name: &'static str,
+        fail_execute: bool,
+        fail_undo: bool,
+        shared: Arc<Mutex<Vec<String>>>
+    }
+
+    impl PostingStep<Details> for MockStep {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn execute<'a>(
+            &'a mut self,
+            ctx: &'a mut PostingContext<Details>
+        ) -> BoxFuture<'a, Result<StepOutcome, PostingError>> {
+            Box::pin(async move {
+                if let Ok(mut log) = self.shared.lock() {
+                    log.push(format!("exec:{}", self.name));
+                }
+                ctx.write_details.log.push(format!("exec:{}", self.name));
+                if self.fail_execute {
+                    return Err(PostingError::new(format!("{} boom", self.name)));
+                }
+                Ok(StepOutcome::Completed)
+            })
+        }
+
+        fn undo<'a>(
+            &'a mut self,
+            ctx: &'a mut PostingContext<Details>
+        ) -> BoxFuture<'a, Result<(), PostingError>> {
+            Box::pin(async move {
+                if let Ok(mut log) = self.shared.lock() {
+                    log.push(format!("undo:{}", self.name));
+                }
+                ctx.write_details.log.push(format!("undo:{}", self.name));
+                if self.fail_undo {
+                    return Err(PostingError::new(format!("{} undo boom", self.name)));
+                }
+                Ok(())
+            })
+        }
+    }
+
+    fn step(
+        name: &'static str,
+        fail_execute: bool,
+        fail_undo: bool,
+        shared: Arc<Mutex<Vec<String>>>
+    ) -> MockStep {
+        MockStep { name, fail_execute, fail_undo, shared }
+    }
+
+    #[tokio::test]
+    async fn all_steps_succeed() {
+        let shared = Arc::new(Mutex::new(Vec::new()));
+        let mut ctl = PostingController::new();
+        ctl.push_step(step("a", false, false, shared.clone()));
+        ctl.push_step(step("b", false, false, shared.clone()));
+        let mut ctx = PostingContext::new(Details::default());
+        let report = ctl.attempt(&mut ctx).await;
+        assert!(report.success);
+        assert_eq!(report.fail_success, 0);
+        assert_eq!(report.completed_steps, vec!["a", "b"]);
+        let log = shared.lock().map(|g| g.clone()).unwrap_or_default();
+        assert_eq!(log, vec!["exec:a", "exec:b"]);
+    }
+
+    #[tokio::test]
+    async fn mid_fail_undoes_in_reverse() {
+        let shared = Arc::new(Mutex::new(Vec::new()));
+        let mut ctl = PostingController::new();
+        ctl.push_step(step("ops", false, false, shared.clone()));
+        ctl.push_step(step("accounting", true, false, shared.clone()));
+        let mut ctx = PostingContext::new(Details::default());
+        let report = ctl.attempt(&mut ctx).await;
+        assert!(!report.success);
+        assert_eq!(report.fail_success, 1);
+        assert_eq!(report.failed_step.as_deref(), Some("accounting"));
+        assert_eq!(report.completed_steps, vec!["ops"]);
+        let log = shared.lock().map(|g| g.clone()).unwrap_or_default();
+        assert_eq!(log, vec!["exec:ops", "exec:accounting", "undo:ops"]);
+    }
+
+    #[tokio::test]
+    async fn undo_fail_sets_fail_success_negative() {
+        let shared = Arc::new(Mutex::new(Vec::new()));
+        let mut ctl = PostingController::new();
+        ctl.push_step(step("ops", false, true, shared.clone()));
+        ctl.push_step(step("accounting", true, false, shared.clone()));
+        let mut ctx = PostingContext::new(Details::default());
+        let report = ctl.attempt(&mut ctx).await;
+        assert!(!report.success);
+        assert_eq!(report.fail_success, -1);
+        assert!(report.errors.iter().any(|e| e.contains("undo")));
+    }
+
+    #[tokio::test]
+    async fn first_step_fail_no_undo() {
+        let shared = Arc::new(Mutex::new(Vec::new()));
+        let mut ctl = PostingController::new();
+        ctl.push_step(step("ops", true, false, shared.clone()));
+        let mut ctx = PostingContext::new(Details::default());
+        let report = ctl.attempt(&mut ctx).await;
+        assert!(!report.success);
+        assert_eq!(report.fail_success, 0);
+        let log = shared.lock().map(|g| g.clone()).unwrap_or_default();
+        assert_eq!(log, vec!["exec:ops"]);
+    }
+}

--- a/src/posting/mod.rs
+++ b/src/posting/mod.rs
@@ -1,0 +1,12 @@
+//! Multi-step posting orchestration (Command + Facade).
+//!
+//! Service authors compose typed [`PostingStep`]s and run them through
+//! [`PostingController::attempt`]. On failure, completed steps are undone in
+//! reverse order (saga compensation). Local DB locking / double-entry math
+//! stay in the service; this module only orchestrates execute/undo.
+
+mod controller;
+mod step;
+
+pub use controller::{PostingContext, PostingController, PostingReport};
+pub use step::{BoxFuture, BoxPostingStep, PostingError, PostingStep, StepOutcome};

--- a/src/posting/step.rs
+++ b/src/posting/step.rs
@@ -1,0 +1,67 @@
+use std::future::Future;
+use std::pin::Pin;
+
+use super::controller::PostingContext;
+
+/// Boxed async step future (avoids requiring `async_trait` on the framework).
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Outcome of a successful [`PostingStep::execute`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StepOutcome {
+    /// Step performed work and may need undo on later failure.
+    Completed,
+    /// Step was a no-op (e.g. idempotent hit); still recorded if needed.
+    Skipped
+}
+
+/// Error from a posting step. Controllers collect messages into the report.
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
+pub struct PostingError {
+    pub message: String
+}
+
+impl PostingError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self { message: message.into() }
+    }
+}
+
+impl From<anyhow::Error> for PostingError {
+    fn from(err: anyhow::Error) -> Self {
+        Self { message: err.to_string() }
+    }
+}
+
+impl From<String> for PostingError {
+    fn from(message: String) -> Self {
+        Self { message }
+    }
+}
+
+impl From<&str> for PostingError {
+    fn from(message: &str) -> Self {
+        Self { message: message.to_string() }
+    }
+}
+
+/// One atomic unit of a multi-step post (Command pattern).
+///
+/// Implement with typed write-details `T` held in [`PostingContext`].
+pub trait PostingStep<T>: Send {
+    fn name(&self) -> &str;
+
+    fn execute<'a>(
+        &'a mut self,
+        ctx: &'a mut PostingContext<T>
+    ) -> BoxFuture<'a, Result<StepOutcome, PostingError>>;
+
+    fn undo<'a>(
+        &'a mut self,
+        ctx: &'a mut PostingContext<T>
+    ) -> BoxFuture<'a, Result<(), PostingError>>;
+}
+
+/// Type-erased step for building a controller from heterogeneous adapters.
+pub type BoxPostingStep<T> = Box<dyn PostingStep<T>>;

--- a/src/repo/into_filter.rs
+++ b/src/repo/into_filter.rs
@@ -8,10 +8,61 @@ use super::map_util::Filter;
 /// `From<UpdateRow> for Vec<FilterOp<Field>>` impls produced by
 /// `#[derive(MaeRepo)]` rely on this trait to pick the correct
 /// [`Filter`] variant for each field type.
+///
+/// # Service enums (e.g. `posting_status`)
+///
+/// Implement [`MaeEnumLabel`] on the enum; [`IntoMaeFilter`] is provided
+/// automatically (including `Option<YourEnum>`).
 pub trait IntoMaeFilter {
     /// Convert `self` into a [`Filter`] using an equality /
     /// string-equality condition appropriate for the value's type.
     fn into_mae_filter(self) -> Filter;
+}
+
+/// Label bridge for service-defined enums used as filterable PG columns.
+///
+/// ```ignore
+/// impl MaeEnumLabel for PostingStatus {
+///     fn mae_enum_label(&self) -> &'static str {
+///         match self {
+///             Self::Active => "active",
+///             Self::Reversed => "reversed",
+///             Self::Reversal => "reversal",
+///         }
+///     }
+///     fn mae_pg_type() -> Option<&'static str> {
+///         Some("posting_status")
+///     }
+/// }
+/// ```
+pub trait MaeEnumLabel {
+    /// Stored / bound label (typically lowercase enum variant).
+    fn mae_enum_label(&self) -> &'static str;
+
+    /// When `Some`, filter uses [`Filter::PgEnumCast`] with this type name.
+    /// When `None`, filter uses plain [`Filter::StringIs`].
+    fn mae_pg_type() -> Option<&'static str> {
+        None
+    }
+}
+
+impl<T: MaeEnumLabel> IntoMaeFilter for T {
+    fn into_mae_filter(self) -> Filter {
+        let label = self.mae_enum_label().to_string();
+        match T::mae_pg_type() {
+            Some(ty) => Filter::PgEnumCast(label, ty),
+            None => Filter::StringIs(label)
+        }
+    }
+}
+
+impl<T: MaeEnumLabel> IntoMaeFilter for Option<T> {
+    fn into_mae_filter(self) -> Filter {
+        match self {
+            Some(v) => v.into_mae_filter(),
+            None => Filter::IsNull
+        }
+    }
 }
 
 impl IntoMaeFilter for i32 {
@@ -216,6 +267,40 @@ mod tests {
             Filter::StringIs(v) => must_eq(v.as_str(), "active"),
             other => panic!("unexpected filter: {other:?}")
         }
+    }
+
+    #[derive(Clone, Copy)]
+    enum SamplePostingStatus {
+        Reversed
+    }
+
+    impl MaeEnumLabel for SamplePostingStatus {
+        fn mae_enum_label(&self) -> &'static str {
+            match self {
+                Self::Reversed => "reversed"
+            }
+        }
+
+        fn mae_pg_type() -> Option<&'static str> {
+            Some("posting_status")
+        }
+    }
+
+    #[test]
+    fn custom_enum_label_uses_pg_enum_cast() {
+        match SamplePostingStatus::Reversed.into_mae_filter() {
+            Filter::PgEnumCast(label, ty) => {
+                must_eq(label.as_str(), "reversed");
+                must_eq(ty, "posting_status");
+            }
+            other => panic!("unexpected filter: {other:?}")
+        }
+    }
+
+    #[test]
+    fn option_custom_enum_none_is_null() {
+        let none: Option<SamplePostingStatus> = None;
+        assert!(matches!(none.into_mae_filter(), Filter::IsNull));
     }
 
     #[test]

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -46,7 +46,7 @@ pub mod prelude {
 
 pub mod filter {
     use super::*;
-    pub use into_filter::IntoMaeFilter;
+    pub use into_filter::{IntoMaeFilter, MaeEnumLabel};
     pub use map_util::{Filter, FilterOp};
 }
 


### PR DESCRIPTION
## Summary
- Add `mae::posting` (`PostingController`, `PostingStep`, typed context) for multi-step execute/undo sagas used by queue intake orchestration.
- Extend filter helpers (`into_filter`) for enum/label mapping used by services.

## Test plan
- [x] Local pre-push smoke-test (nextest + coverage + clippy + deny)
- [ ] CI integrity + integration green

Depends on: none (mae_macros 0.1.9 crates.io)