### PR TITLE
fix(cors): allow QUERY method for browser preflights

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mae"
-version = "0.3.13"
+version = "0.3.14"
 edition = "2024"
 license = "MIT"
 description = "Opinionated async Rust framework for building Mae-Technologies micro-services — app scaffolding, repo layer, middleware, and test utilities."

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -58,10 +58,23 @@ pub fn session_middleware(
     .build()
 }
 
+/// CORS middleware for Mae FE-facing services (primarily `ru_api_service`).
+///
+/// # Custom HTTP methods
+/// [`Cors::allow_any_method`] only allows the **standard** verb set (GET/POST/…).
+/// Mae list endpoints use the custom **`QUERY`** method (JSON body + filters).
+/// Browsers preflight that with `Access-Control-Request-Method: QUERY`; if
+/// `QUERY` is missing from `Access-Control-Allow-Methods`, preflight fails with
+/// `400 Requested method is not allowed` and the SPA surfaces a CORS error.
+///
+/// We therefore seed standard methods via `allow_any_method` and **insert** `QUERY`.
 pub fn cors_middleware(allowed_origin: String) -> Cors {
     Cors::default()
         .allowed_origin(&allowed_origin)
+        // Standard verbs only (actix-cors misnomer — does not include custom methods).
         .allow_any_method()
+        // Mae list endpoints use custom QUERY (JSON body); browsers preflight it.
+        .allowed_methods(["QUERY"])
         .allow_any_header()
         .supports_credentials()
 }


### PR DESCRIPTION
## Summary
Staging CORS preflight for `Access-Control-Request-Method: QUERY` returns **400 Requested method is not allowed**. Browser shows CORS errors on bookkeeper timesheet/paystub QUERY routes.

## Root cause
`actix_cors::Cors::allow_any_method()` only allows the **standard** HTTP verb set. Mae list endpoints use custom **QUERY**. Not a webUI regression — FE correctly moved to QUERY; CORS was never extended.

## Fix
`.allowed_methods(["QUERY"])` after `allow_any_method()`. Version **0.3.14**.

## Verify after publish + api rebuild
```bash
curl -i -X OPTIONS 'https://api.staging.statbook.io/bookkeeper/timesheet/operations-intake/get/5' \
  -H 'Origin: https://staging.statbook.io' \
  -H 'Access-Control-Request-Method: QUERY'
# expect 200 and Access-Control-Allow-Methods containing QUERY
```